### PR TITLE
fix: add ignoreDeprecations for TypeScript baseUrl deprecation

### DIFF
--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -16,6 +16,7 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
     "paths": {
       "@/*": ["./src/*"],
       "@shared/*": ["../src/*"],

--- a/web-client/tsconfig.json
+++ b/web-client/tsconfig.json
@@ -17,6 +17,7 @@
     "noFallthroughCasesInSwitch": true,
     "resolveJsonModule": true,
     "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
     "paths": {
       "@/*": ["src/*"],
       "@shared/*": ["../src/*"],


### PR DESCRIPTION
Dependabot bumps updated TypeScript to a version that deprecates 'baseUrl' in tsconfig.\n\nAdds 'ignoreDeprecations: 6.0' to both client/tsconfig.json and web-client/tsconfig.json.