### PR TITLE
fix: migrate to Tailwind v4 and fix TS null check

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -49,6 +49,7 @@
     "autoprefixer": "^10.5.2",
     "postcss": "^8.5.16",
     "tailwindcss": "^4.3.2",
+    "@tailwindcss/postcss": "^4.3.2",
     "typescript": "~6.0.3",
     "vite": "^8.1.3",
     "vue-tsc": "^3.3.6"

--- a/client/postcss.config.js
+++ b/client/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
   plugins: {
-    tailwindcss: {},
+    "@tailwindcss/postcss": {},
     autoprefixer: {},
   },
 };

--- a/client/src/components/modals/LibrarySettingsModal.vue
+++ b/client/src/components/modals/LibrarySettingsModal.vue
@@ -814,7 +814,7 @@ watch(transformMatches, () => {
                       class="underline decoration-dotted underline-offset-2 hover:text-stone-200"
                       @click="
                         openReleaseUrl(
-                          releaseTagUrl(availableUpdate.version),
+                          releaseTagUrl(availableUpdate!.version),
                         )
                       "
                     >

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -1,6 +1,4 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
 
 /* Default (dark) theme – no data-theme or data-theme="dark" */
 html, body {

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -16,6 +16,7 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
     "paths": {
       "@/*": ["./src/*"],
       "@shared/*": ["../src/*"],

--- a/web-client/package.json
+++ b/web-client/package.json
@@ -21,6 +21,7 @@
     "autoprefixer": "^10.5.0",
     "postcss": "^8.5.15",
     "tailwindcss": "^4.3.2",
+    "@tailwindcss/postcss": "^4.3.2",
     "typescript": "~6.0.3",
     "vite": "^8.1.3",
     "vite-plugin-pwa": "^1.3.0",

--- a/web-client/postcss.config.js
+++ b/web-client/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
   plugins: {
-    tailwindcss: {},
+    "@tailwindcss/postcss": {},
     autoprefixer: {},
   },
 };

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -1,6 +1,4 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
 
 :root {
   --accent: #5b7c32;

--- a/web-client/tsconfig.json
+++ b/web-client/tsconfig.json
@@ -17,6 +17,7 @@
     "noFallthroughCasesInSwitch": true,
     "resolveJsonModule": true,
     "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
     "paths": {
       "@/*": ["src/*"],
       "@shared/*": ["../src/*"],


### PR DESCRIPTION
Fixes two CI failures from Dependabot bumps:\n\n1. **Tailwind v4 migration**: Replaced @tailwind directives with @import 'tailwindcss', updated PostCSS config to use @tailwindcss/postcss, and added the new dependency\n2. **TS strict null check**: Added non-null assertion on availableUpdate.version in LibrarySettingsModal.vue