### PR TITLE
WEB — Mobile-first revival (Phase 5, NER-277–287)

### DIFF
--- a/web-client/index.html
+++ b/web-client/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#1c1917" />
 
     <!-- iOS PWA -->

--- a/web-client/src/App.vue
+++ b/web-client/src/App.vue
@@ -12,6 +12,7 @@
         @toggle-sidebar="sidebarOpen = !sidebarOpen"
         @back="openAlbum = null"
         @open-stats="showStats = true"
+        @open-mobile-search="mobileSearchOpen = true"
       />
 
       <div class="flex min-h-0 flex-1 overflow-hidden">
@@ -33,14 +34,16 @@
         </main>
       </div>
 
-      <PlayerBar />
+      <PlayerBar :overlay-open="playerOverlayOpen" @update:overlayOpen="playerOverlayOpen = $event" />
+      <MobileTabBar :active="activeMobileTab" @select="onMobileTabSelect" />
       <StatsModal :open="showStats" @close="showStats = false" />
+      <MobileSearchScreen :open="mobileSearchOpen" @close="mobileSearchOpen = false" @open-album="openAlbum = $event" />
     </template>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, watchEffect } from "vue";
+import { ref, onMounted, watchEffect, computed } from "vue";
 import ConnectionScreen from "./components/ConnectionScreen.vue";
 import OfflineBanner from "./components/OfflineBanner.vue";
 import LibraryHeader from "./components/LibraryHeader.vue";
@@ -50,6 +53,8 @@ import AlbumDetailView from "./components/AlbumDetailView.vue";
 import TrackTable from "./components/TrackTable.vue";
 import PlayerBar from "./components/PlayerBar.vue";
 import StatsModal from "./components/StatsModal.vue";
+import MobileTabBar, { type MobileTab } from "./components/MobileTabBar.vue";
+import MobileSearchScreen from "./components/MobileSearchScreen.vue";
 import { isConnected, disconnect as apiDisconnect } from "./api/client";
 import { useLibraryStore } from "./stores/library";
 import { usePlaylistStore } from "./stores/playlists";
@@ -72,15 +77,72 @@ watchEffect(() => {
 const sidebarOpen = ref(window.innerWidth >= 768);
 const openAlbum = ref<AlbumGridItem | null>(null);
 const showStats = ref(false);
+const playerOverlayOpen = ref(false);
+const mobileSearchOpen = ref(false);
+// Which mobile tab the user is on (music = full library, albums = grid)
+const mobileSection = ref<"music" | "albums">(window.innerWidth < 768 ? "music" : "albums");
+
+// Keep the now-playing overlay in sync with the tab bar
+const activeMobileTab = computed<MobileTab>(() => {
+  if (playerOverlayOpen.value) return "now-playing";
+  if (sidebarOpen.value) return "playlists";
+  if (openAlbum.value) return "albums";
+  return mobileSection.value;
+});
+
+function onMobileTabSelect(tab: MobileTab): void {
+  switch (tab) {
+    case "music":
+      sidebarOpen.value = false;
+      openAlbum.value = null;
+      mobileSection.value = "music";
+      break;
+    case "albums":
+      sidebarOpen.value = false;
+      openAlbum.value = null;
+      lib.setViewMode("grid");
+      mobileSection.value = "albums";
+      break;
+    case "playlists":
+      sidebarOpen.value = true;
+      break;
+    case "now-playing":
+      if (!lib.nowPlaying) {
+        // Nothing playing — the tab still behaves as a shortcut to the player
+        sidebarOpen.value = false;
+        openAlbum.value = null;
+        return;
+      }
+      playerOverlayOpen.value = true;
+      break;
+  }
+}
+
+// Theme-color meta updates with the active theme (notch / status bar tint)
+function applyThemeColor(): void {
+  const theme = localStorage.getItem("muorg-web-theme") ?? "dark";
+  let meta = document.querySelector('meta[name="theme-color"]');
+  if (!meta) {
+    meta = document.createElement("meta");
+    meta.setAttribute("name", "theme-color");
+    document.head.appendChild(meta);
+  }
+  meta.setAttribute("content", theme === "light" ? "#fafaf9" : "#1c1917");
+}
 
 onMounted(() => {
   const theme = localStorage.getItem("muorg-web-theme") ?? "dark";
   document.documentElement.setAttribute("data-theme", theme);
+  applyThemeColor();
 
   if (connected.value) {
     loadData();
   }
 });
+
+// Keep theme-color in sync if the theme changes at runtime
+const themeObserver = new MutationObserver(() => applyThemeColor());
+themeObserver.observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] });
 
 function onConnected(): void {
   connected.value = true;
@@ -95,6 +157,8 @@ function disconnect(): void {
   apiDisconnect();
   connected.value = false;
   openAlbum.value = null;
+  playerOverlayOpen.value = false;
+  mobileSearchOpen.value = false;
   lib.$reset();
   playlistStore.$reset();
 }

--- a/web-client/src/components/AlbumDetailView.vue
+++ b/web-client/src/components/AlbumDetailView.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="flex min-h-0 flex-1 flex-col overflow-hidden">
     <!-- Album header -->
-    <div class="flex shrink-0 items-center gap-5 border-b border-stone-800 px-5 py-4">
+    <div class="flex shrink-0 items-center gap-4 border-b border-stone-800 px-4 py-4 md:gap-5 md:px-5">
       <!-- Cover art -->
-      <div class="relative h-28 w-28 shrink-0 overflow-hidden rounded bg-stone-800">
+      <div class="relative h-36 w-36 shrink-0 overflow-hidden rounded-lg bg-stone-800 md:h-28 md:w-28 md:rounded">
         <img
           v-if="coverUrl"
           :src="coverUrl"
@@ -16,26 +16,49 @@
       </div>
 
       <!-- Info -->
-      <div class="min-w-0">
-        <div class="truncate text-lg font-semibold text-stone-100">{{ item.album }}</div>
+      <div class="min-w-0 flex-1">
+        <div class="truncate text-lg font-semibold text-stone-100 md:text-xl">{{ item.album }}</div>
         <div class="mt-1 truncate text-sm text-stone-300">{{ item.albumArtist }}</div>
         <div v-if="item.year" class="mt-1 text-xs text-stone-500">{{ item.year }}</div>
         <div class="mt-2 text-xs text-stone-500">{{ tracks.length }} tracks · {{ totalDuration }}</div>
       </div>
 
-      <!-- Play button -->
+      <!-- Play button: FAB on mobile, text button on desktop -->
       <button
         type="button"
-        class="ml-auto flex items-center gap-2 rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-[var(--accent-hover)]"
+        class="ml-auto flex h-14 w-14 shrink-0 items-center justify-center rounded-full bg-accent text-white shadow-lg active:bg-[var(--accent-hover)] md:h-auto md:w-auto md:gap-2 md:rounded-lg md:px-4 md:py-2 md:text-sm md:font-medium md:shadow-none"
         @click="lib.playAlbum(item)"
       >
-        <FeatherIcon name="play" class="h-4 w-4" />
-        Play
+        <FeatherIcon name="play" class="h-6 w-6 md:h-4 md:w-4" />
+        <span class="hidden md:inline">Play</span>
       </button>
     </div>
 
     <!-- Track list -->
-    <div class="flex-1 overflow-auto">
+    <div class="relative min-h-0 flex-1 overflow-hidden">
+      <!-- Compact sticky bar (mobile, after scrolling past the hero) -->
+      <div
+        v-if="compactBar"
+        class="absolute inset-x-0 top-0 z-20 flex items-center gap-2 border-b border-stone-800 bg-stone-900/95 px-3 py-1.5 backdrop-blur sm:hidden"
+      >
+        <div class="h-8 w-8 shrink-0 overflow-hidden rounded bg-stone-800">
+          <img v-if="coverUrl" :src="coverUrl" :alt="item.album" class="h-full w-full object-cover" />
+          <div v-else class="flex h-full w-full items-center justify-center text-stone-600">♪</div>
+        </div>
+        <div class="min-w-0 flex-1">
+          <div class="truncate text-sm font-medium text-stone-100">{{ item.album }}</div>
+          <div class="truncate text-xs text-stone-500">{{ item.albumArtist }}</div>
+        </div>
+        <button
+          type="button"
+          class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-accent text-white active:bg-[var(--accent-hover)]"
+          aria-label="Play album"
+          @click="lib.playAlbum(item)"
+        >
+          <FeatherIcon name="play" class="h-5 w-5" />
+        </button>
+      </div>
+      <div ref="listScrollEl" class="h-full overflow-auto" @scroll="onListScroll">
       <table class="w-full border-collapse text-left">
         <thead class="sticky top-0 z-10 bg-stone-900 text-xs uppercase tracking-wide text-stone-500">
           <tr class="border-b border-stone-700">
@@ -58,11 +81,22 @@
             @touchmove.passive="onTouchMove"
             @touchend="onTouchEnd"
           >
-            <td class="py-2 pl-4 pr-2 text-right text-xs text-stone-500">
+            <td class="py-2.5 pl-4 pr-2 text-right text-xs text-stone-500 md:py-2">
               {{ track.track_number ?? '—' }}
             </td>
-            <td class="max-w-0 py-2 pr-4">
-              <div class="truncate text-sm text-stone-200">{{ track.title ?? 'Unknown' }}</div>
+            <td class="max-w-0 py-2.5 pr-4 md:py-2">
+              <div class="flex items-center gap-2">
+                <img
+                  v-if="coverThumb(track)"
+                  :src="coverThumb(track)"
+                  :alt="track.title ?? ''"
+                  class="h-9 w-9 shrink-0 rounded object-cover sm:hidden"
+                />
+                <div class="min-w-0">
+                  <div class="truncate text-sm text-stone-200">{{ track.title ?? 'Unknown' }}</div>
+                  <div class="truncate text-xs text-stone-400 sm:hidden">{{ track.artist ?? track.album_artist ?? '—' }}</div>
+                </div>
+              </div>
             </td>
             <td class="hidden max-w-0 py-2 pr-4 sm:table-cell">
               <div class="truncate text-xs text-stone-400">{{ track.artist ?? track.album_artist ?? '—' }}</div>
@@ -79,6 +113,7 @@
           </tr>
         </tbody>
       </table>
+      </div>
     </div>
   </div>
 
@@ -115,10 +150,23 @@ const props = defineProps<{ item: AlbumGridItem }>();
 const lib = useLibraryStore();
 const playlistStore = usePlaylistStore();
 
+const listScrollEl = ref<HTMLElement | null>(null);
+const compactBar = ref(false);
+
+function onListScroll(): void {
+  compactBar.value = (listScrollEl.value?.scrollTop ?? 0) > 120;
+}
+
 const coverUrl = computed(() => {
   if (!props.item.hasCover || props.item.coverTrackId === null) return null;
   return lib.coverCache.get(props.item.coverTrackId) ?? null;
 });
+
+function coverThumb(track: CatalogTrack): string | undefined {
+  if (!track.has_cover) return undefined;
+  lib.requestCover(track.id);
+  return lib.coverCache.get(track.id) ?? undefined;
+}
 
 const tracks = computed(() => {
   const ids = new Set(props.item.trackIds);

--- a/web-client/src/components/AlbumGrid.vue
+++ b/web-client/src/components/AlbumGrid.vue
@@ -1,40 +1,55 @@
 <template>
-  <div class="flex-1 overflow-y-auto p-4">
-    <div
-      v-if="lib.loading"
-      class="flex h-32 items-center justify-center text-stone-500 text-sm"
-    >
-      Loading library…
+  <div ref="scrollEl" class="relative flex-1 overflow-y-auto overscroll-contain">
+    <!-- Pull-to-refresh indicator -->
+    <div class="pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center" :style="indicatorStyle">
+      <div
+        class="mt-2 flex h-9 w-9 items-center justify-center rounded-full border border-stone-600 bg-stone-800 shadow-lg"
+      >
+        <FeatherIcon name="refresh-cw" class="h-4 w-4 text-accent" :class="ptr.refreshing ? 'animate-spin' : ''" />
+      </div>
     </div>
 
-    <div
-      v-else-if="lib.error"
-      class="flex h-32 flex-col items-center justify-center gap-2 text-sm"
-    >
-      <span class="text-red-400">Failed to load library: {{ lib.error }}</span>
-      <button class="text-xs text-stone-400 underline hover:text-stone-200" @click="lib.loadLibrary()">Retry</button>
-    </div>
+    <div :style="{ transform: contentTransform }">
+      <!-- Skeleton loading state -->
+      <div v-if="lib.loading" class="grid gap-3 p-4" style="grid-template-columns: repeat(auto-fill, minmax(160px, 1fr))">
+        <div v-for="i in 8" :key="i" class="flex min-h-[220px] flex-col overflow-hidden rounded border border-stone-800">
+          <div class="skeleton h-40 w-full rounded-none" />
+          <div class="space-y-1.5 bg-stone-900/90 px-3 pb-3 pt-2.5">
+            <div class="skeleton h-3.5 w-3/4" />
+            <div class="skeleton h-3 w-1/2" />
+          </div>
+        </div>
+      </div>
 
-    <div
-      v-else-if="items.length === 0"
-      class="flex h-32 items-center justify-center text-stone-500 text-sm"
-    >
-      No albums found.
-    </div>
+      <div
+        v-else-if="lib.error"
+        class="flex h-32 flex-col items-center justify-center gap-2 p-4 text-sm"
+      >
+        <span class="text-red-400">Failed to load library: {{ lib.error }}</span>
+        <button class="text-xs text-stone-400 underline hover:text-stone-200" @click="lib.loadLibrary()">Retry</button>
+      </div>
 
-    <div
-      v-else
-      class="grid gap-3"
-      style="grid-template-columns: repeat(auto-fill, minmax(160px, 1fr))"
-    >
-      <AlbumCard
-        v-for="item in items"
-        :key="item.key"
-        :item="item"
-        :is-playing="isAlbumPlaying(item)"
-        @play="emit('open-album', item)"
-        @contextmenu="openAlbumMenu($event, item)"
-      />
+      <div
+        v-else-if="items.length === 0"
+        class="flex h-32 items-center justify-center p-4 text-sm text-stone-500"
+      >
+        No albums found.
+      </div>
+
+      <div
+        v-else
+        class="grid gap-3 p-4"
+        style="grid-template-columns: repeat(auto-fill, minmax(160px, 1fr))"
+      >
+        <AlbumCard
+          v-for="item in items"
+          :key="item.key"
+          :item="item"
+          :is-playing="isAlbumPlaying(item)"
+          @play="emit('open-album', item)"
+          @contextmenu="openAlbumMenu($event, item)"
+        />
+      </div>
     </div>
 
     <!-- Album context menu -->
@@ -43,8 +58,10 @@
       <div
         v-if="ctxItem && ctxPos"
         class="ctx-menu fixed z-50"
+        :class="isMobile ? 'ctx-sheet' : ''"
         :style="{ top: ctxPos.y + 'px', left: ctxPos.x + 'px' }"
       >
+        <div class="ctx-sheet-handle" />
         <button class="ctx-menu-item" @click.stop="emit('open-album', ctxItem!); ctxItem = null">
           <FeatherIcon name="disc" class="h-3.5 w-3.5" />
           Open album
@@ -75,6 +92,7 @@ import AlbumCard from "./AlbumCard.vue";
 import FeatherIcon from "@shared/components/FeatherIcon.vue";
 import { useLibraryStore } from "../stores/library";
 import { usePlaylistStore } from "../stores/playlists";
+import { usePullToRefresh } from "../composables/usePullToRefresh";
 import type { AlbumGridItem } from "../types";
 
 const emit = defineEmits<{ "open-album": [item: AlbumGridItem] }>();
@@ -82,6 +100,14 @@ const emit = defineEmits<{ "open-album": [item: AlbumGridItem] }>();
 const lib = useLibraryStore();
 const playlistStore = usePlaylistStore();
 const items = computed(() => lib.albumGridItems);
+
+const scrollEl = ref<HTMLElement | null>(null);
+const ptr = usePullToRefresh(scrollEl, async () => {
+  await Promise.all([lib.loadLibrary(), playlistStore.loadPlaylists()]);
+});
+const { indicatorStyle, contentTransform } = ptr;
+
+const isMobile = computed(() => window.matchMedia("(max-width: 639px)").matches);
 
 watch(() => lib.revealTrackId, (id) => {
   if (id === null) return;

--- a/web-client/src/components/LibraryHeader.vue
+++ b/web-client/src/components/LibraryHeader.vue
@@ -1,10 +1,10 @@
 <template>
-  <header class="flex min-w-0 items-start gap-2 border-b border-stone-700 bg-stone-900 px-4 py-2">
+  <header class="safe-top flex min-w-0 items-start gap-2 border-b border-stone-700 bg-stone-900 px-4 py-2">
 
     <!-- Mobile sidebar toggle -->
     <button
       type="button"
-      class="mr-1 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded border border-stone-600 bg-stone-800 text-stone-400 hover:bg-stone-700 hover:text-stone-200 md:hidden"
+      class="mr-1 inline-flex h-10 w-10 shrink-0 items-center justify-center rounded border border-stone-600 bg-stone-800 text-stone-400 hover:bg-stone-700 hover:text-stone-200 active:bg-stone-700 md:h-8 md:w-8 md:hidden"
       aria-label="Toggle sidebar"
       @click="emit('toggle-sidebar')"
     >
@@ -18,7 +18,7 @@
       <button
         v-if="props.showBack"
         type="button"
-        class="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded border border-stone-600 bg-stone-800 text-stone-400 hover:bg-stone-700 hover:text-stone-200"
+        class="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded border border-stone-600 bg-stone-800 text-stone-400 hover:bg-stone-700 hover:text-stone-200 active:bg-stone-700 md:h-8 md:w-8"
         aria-label="Back"
         @click="emit('back')"
       >
@@ -46,10 +46,10 @@
       <div class="flex shrink-0 items-center">
         <button
           type="button"
-          class="inline-flex h-8 w-8 shrink-0 items-center justify-center border border-stone-600 bg-stone-800 text-stone-400 hover:bg-stone-700 hover:text-stone-200"
+          class="inline-flex h-10 w-10 shrink-0 items-center justify-center border border-stone-600 bg-stone-800 text-stone-400 hover:bg-stone-700 hover:text-stone-200 active:bg-stone-700 md:h-8 md:w-8"
           :class="searchExpanded ? 'rounded-l border-r-0' : 'rounded'"
           aria-label="Search"
-          @click="expandSearch"
+          @click="onSearchClick"
         >
           <FeatherIcon name="search" class="h-4 w-4" />
         </button>
@@ -64,7 +64,7 @@
               :tabindex="searchExpanded ? 0 : -1"
               type="text"
               placeholder="Search title, artist, album…"
-              class="h-8 w-[212px] rounded-r border border-l-0 border-stone-600 bg-stone-800 py-0 pl-2 pr-7 text-sm text-stone-200 placeholder-stone-500"
+              class="h-10 w-[212px] rounded-r border border-l-0 border-stone-600 bg-stone-800 py-0 pl-2 pr-7 text-sm text-stone-200 placeholder-stone-500 md:h-8"
               @input="lib.searchQuery = ($event.target as HTMLInputElement).value"
               @blur="onSearchBlur"
               @keydown.escape="lib.searchQuery = ''; searchExpandedLocal = false"
@@ -86,7 +86,7 @@
       <div v-if="viewMode === 'table'" ref="groupByRef" class="relative shrink-0">
         <button
           type="button"
-          class="flex items-center gap-1.5 whitespace-nowrap rounded border border-stone-600 bg-stone-800 px-2 py-1 text-sm text-stone-200 hover:border-stone-500 hover:bg-stone-700"
+          class="flex items-center gap-1.5 whitespace-nowrap rounded border border-stone-600 bg-stone-800 px-2 py-2 text-sm text-stone-200 hover:border-stone-500 hover:bg-stone-700 active:bg-stone-700 md:py-1"
           :class="groupByOpen ? 'border-stone-500 bg-stone-700' : ''"
           @click="groupByOpen = !groupByOpen"
         >
@@ -119,7 +119,7 @@
       <div v-if="viewMode === 'grid'" ref="gridSortRef" class="relative shrink-0">
         <button
           type="button"
-          class="flex items-center gap-1.5 whitespace-nowrap rounded border border-stone-600 bg-stone-800 px-2 py-1 text-sm text-stone-200 hover:border-stone-500 hover:bg-stone-700"
+          class="flex items-center gap-1.5 whitespace-nowrap rounded border border-stone-600 bg-stone-800 px-2 py-2 text-sm text-stone-200 hover:border-stone-500 hover:bg-stone-700 active:bg-stone-700 md:py-1"
           :class="gridSortOpen ? 'border-stone-500 bg-stone-700' : ''"
           @click="gridSortOpen = !gridSortOpen"
         >
@@ -152,7 +152,7 @@
       <div class="flex items-center gap-1 rounded border border-stone-600 bg-stone-800 p-0.5">
         <button
           type="button"
-          class="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded transition-colors"
+          class="inline-flex h-10 w-10 md:h-6 md:w-6 shrink-0 items-center justify-center rounded transition-colors"
           :class="viewMode === 'grid' ? 'bg-stone-600 text-stone-100' : 'text-stone-400 hover:bg-stone-700 hover:text-stone-200'"
           aria-label="Album grid layout"
           @click="lib.setViewMode('grid')"
@@ -161,7 +161,7 @@
         </button>
         <button
           type="button"
-          class="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded transition-colors"
+          class="inline-flex h-10 w-10 md:h-6 md:w-6 shrink-0 items-center justify-center rounded transition-colors"
           :class="viewMode === 'table' ? 'bg-stone-600 text-stone-100' : 'text-stone-400 hover:bg-stone-700 hover:text-stone-200'"
           aria-label="Table layout"
           @click="lib.setViewMode('table')"
@@ -177,7 +177,7 @@
       >
         <button
           type="button"
-          class="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded transition-colors"
+          class="inline-flex h-10 w-10 md:h-6 md:w-6 shrink-0 items-center justify-center rounded transition-colors"
           :class="lib.tableArtSize === 'small' ? 'bg-stone-600 text-stone-100' : 'text-stone-400 hover:bg-stone-700 hover:text-stone-200'"
           title="Small cover art"
           @click="lib.setTableArtSize('small')"
@@ -186,7 +186,7 @@
         </button>
         <button
           type="button"
-          class="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded transition-colors"
+          class="inline-flex h-10 w-10 md:h-6 md:w-6 shrink-0 items-center justify-center rounded transition-colors"
           :class="lib.tableArtSize === 'large' ? 'bg-stone-600 text-stone-100' : 'text-stone-400 hover:bg-stone-700 hover:text-stone-200'"
           title="Large cover art"
           @click="lib.setTableArtSize('large')"
@@ -201,7 +201,7 @@
     <div class="flex shrink-0 items-center gap-1">
       <button
         type="button"
-        class="hidden sm:inline-flex h-6 w-6 shrink-0 items-center justify-center rounded text-stone-500 hover:bg-stone-600 hover:text-stone-200"
+        class="hidden sm:inline-flex h-10 w-10 md:h-6 md:w-6 shrink-0 items-center justify-center rounded text-stone-500 hover:bg-stone-600 hover:text-stone-200 active:bg-stone-600"
         title="Mouse controls"
         @click="showKeymap = true"
       >
@@ -210,7 +210,7 @@
       <button
         v-if="canInstall"
         type="button"
-        class="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded text-stone-500 hover:bg-stone-600 hover:text-stone-200"
+        class="inline-flex h-10 w-10 md:h-6 md:w-6 shrink-0 items-center justify-center rounded text-stone-500 hover:bg-stone-600 hover:text-stone-200 active:bg-stone-600"
         :title="isIos ? 'Install: tap Share → Add to Home Screen' : 'Install Muorg as app'"
         @click="install"
       >
@@ -219,7 +219,7 @@
       <div class="relative" ref="versionRef">
         <button
           type="button"
-          class="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded text-stone-500 hover:bg-stone-600 hover:text-stone-200"
+          class="inline-flex h-10 w-10 md:h-6 md:w-6 shrink-0 items-center justify-center rounded text-stone-500 hover:bg-stone-600 hover:text-stone-200 active:bg-stone-600"
           @click="versionOpen = !versionOpen"
         >
           <FeatherIcon name="info" class="h-4 w-4" />
@@ -233,7 +233,7 @@
       </div>
       <button
         type="button"
-        class="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded text-stone-500 hover:bg-stone-600 hover:text-stone-200"
+        class="inline-flex h-10 w-10 md:h-6 md:w-6 shrink-0 items-center justify-center rounded text-stone-500 hover:bg-stone-600 hover:text-stone-200 active:bg-stone-600"
         title="Statistics"
         @click="emit('open-stats')"
       >
@@ -241,7 +241,7 @@
       </button>
       <button
         type="button"
-        class="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded text-stone-500 hover:bg-stone-600 hover:text-stone-200"
+        class="inline-flex h-10 w-10 md:h-6 md:w-6 shrink-0 items-center justify-center rounded text-stone-500 hover:bg-stone-600 hover:text-stone-200 active:bg-stone-600"
         title="Disconnect"
         @click="emit('disconnect')"
       >
@@ -269,6 +269,7 @@ const emit = defineEmits<{
   "toggle-sidebar": [];
   back: [];
   "open-stats": [];
+  "open-mobile-search": [];
 }>();
 
 const lib = useLibraryStore();
@@ -298,6 +299,17 @@ const searchExpanded = computed(() => searchExpandedLocal.value || !!lib.searchQ
 function expandSearch() {
   searchExpandedLocal.value = true;
   nextTick(() => searchInputRef.value?.focus());
+}
+
+// On phones the search button opens the full-screen search screen instead
+const isMobile = computed(() => window.matchMedia("(max-width: 767px)").matches);
+
+function onSearchClick(): void {
+  if (isMobile.value) {
+    emit("open-mobile-search");
+    return;
+  }
+  expandSearch();
 }
 
 function onSearchBlur() {

--- a/web-client/src/components/MobileSearchScreen.vue
+++ b/web-client/src/components/MobileSearchScreen.vue
@@ -1,0 +1,295 @@
+<template>
+  <Teleport to="body">
+    <Transition
+      enter-active-class="transition-opacity duration-150"
+      enter-from-class="opacity-0"
+      leave-active-class="transition-opacity duration-150"
+      leave-to-class="opacity-0"
+    >
+      <div v-if="open" class="fixed inset-0 z-[60] flex flex-col bg-stone-900 md:hidden">
+        <!-- Search header -->
+        <div class="safe-top flex shrink-0 items-center gap-2 border-b border-stone-800 px-3 py-2.5">
+          <button
+            type="button"
+            class="flex h-10 w-10 shrink-0 items-center justify-center rounded text-stone-400 active:bg-stone-800"
+            aria-label="Close search"
+            @click="close"
+          >
+            <FeatherIcon name="arrow-left" class="h-5 w-5" />
+          </button>
+          <div class="relative min-w-0 flex-1">
+            <FeatherIcon name="search" class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-stone-500" />
+            <input
+              ref="inputRef"
+              v-model="query"
+              type="search"
+              placeholder="Search title, artist, album…"
+              enterkeyhint="search"
+              class="h-11 w-full rounded-full border border-stone-700 bg-stone-800 pl-9 pr-4 text-sm text-stone-100 placeholder-stone-500 focus:border-accent focus:outline-none"
+            />
+            <button
+              v-if="query"
+              type="button"
+              class="absolute right-2 top-1/2 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full text-stone-400 active:bg-stone-700"
+              aria-label="Clear search"
+              @click="query = ''"
+            >
+              <FeatherIcon name="x" class="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+
+        <!-- Body -->
+        <div class="min-h-0 flex-1 overflow-y-auto overscroll-contain px-3 pb-[max(env(safe-area-inset-bottom,0px),0.75rem)]">
+          <!-- Recent searches -->
+          <div v-if="!query" class="pt-4">
+            <div class="flex items-center justify-between px-1 pb-2">
+              <span class="text-xs font-semibold uppercase tracking-wide text-stone-500">Recent</span>
+              <button
+                v-if="recentSearches.length"
+                type="button"
+                class="text-xs text-stone-500 underline underline-offset-2 active:text-stone-300"
+                @click="clearRecent"
+              >
+                Clear
+              </button>
+            </div>
+            <div v-if="recentSearches.length === 0" class="px-1 py-8 text-center text-sm text-stone-600">
+              Search your library, albums, artists and playlists.
+            </div>
+            <button
+              v-for="r in recentSearches"
+              :key="r"
+              type="button"
+              class="flex h-11 w-full items-center gap-3 rounded-lg px-3 text-left text-sm text-stone-300 active:bg-stone-800"
+              @click="query = r"
+            >
+              <FeatherIcon name="clock" class="h-4 w-4 shrink-0 text-stone-500" />
+              <span class="min-w-0 flex-1 truncate">{{ r }}</span>
+            </button>
+          </div>
+
+          <!-- Results -->
+          <template v-else>
+            <section v-if="tracks.length" class="pt-4">
+              <h2 class="px-1 pb-1.5 text-xs font-semibold uppercase tracking-wide text-stone-500">Tracks</h2>
+              <button
+                v-for="t in tracks"
+                :key="'t' + t.id"
+                type="button"
+                class="flex min-h-12 w-full items-center gap-3 rounded-lg px-2 text-left active:bg-stone-800/70"
+                @click="playTrack(t)"
+              >
+                <span class="flex h-9 w-9 shrink-0 items-center justify-center rounded bg-stone-800 text-stone-400">
+                  <FeatherIcon :name="t.id === lib.nowPlaying?.id ? 'volume-2' : 'music'" class="h-4 w-4" />
+                </span>
+                <span class="min-w-0 flex-1">
+                  <span class="block truncate text-sm text-stone-100">{{ t.title ?? '—' }}</span>
+                  <span class="block truncate text-xs text-stone-500">{{ t.artist ?? t.album_artist ?? '—' }}</span>
+                </span>
+              </button>
+            </section>
+
+            <section v-if="albums.length" class="pt-4">
+              <h2 class="px-1 pb-1.5 text-xs font-semibold uppercase tracking-wide text-stone-500">Albums</h2>
+              <button
+                v-for="a in albums"
+                :key="'a' + a.key"
+                type="button"
+                class="flex min-h-12 w-full items-center gap-3 rounded-lg px-2 text-left active:bg-stone-800/70"
+                @click="openAlbum(a)"
+              >
+                <span class="flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded bg-stone-800">
+                  <img v-if="albumCover(a)" :src="albumCover(a)" :alt="a.album" class="h-full w-full object-cover" />
+                  <FeatherIcon v-else name="disc" class="h-4 w-4 text-stone-500" />
+                </span>
+                <span class="min-w-0 flex-1">
+                  <span class="block truncate text-sm text-stone-100">{{ a.album }}</span>
+                  <span class="block truncate text-xs text-stone-500">{{ a.albumArtist }}</span>
+                </span>
+              </button>
+            </section>
+
+            <section v-if="artists.length" class="pt-4">
+              <h2 class="px-1 pb-1.5 text-xs font-semibold uppercase tracking-wide text-stone-500">Artists</h2>
+              <button
+                v-for="name in artists"
+                :key="'ar' + name"
+                type="button"
+                class="flex min-h-12 w-full items-center gap-3 rounded-lg px-2 text-left active:bg-stone-800/70"
+                @click="openArtist(name)"
+              >
+                <span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-stone-700 text-stone-400">
+                  <FeatherIcon name="user" class="h-4 w-4" />
+                </span>
+                <span class="min-w-0 flex-1 truncate text-sm text-stone-100">{{ name }}</span>
+              </button>
+            </section>
+
+            <section v-if="playlists.length" class="pt-4">
+              <h2 class="px-1 pb-1.5 text-xs font-semibold uppercase tracking-wide text-stone-500">Playlists</h2>
+              <button
+                v-for="p in playlists"
+                :key="'p' + p.id"
+                type="button"
+                class="flex min-h-12 w-full items-center gap-3 rounded-lg px-2 text-left active:bg-stone-800/70"
+                @click="openPlaylist(p.id)"
+              >
+                <span class="flex h-9 w-9 shrink-0 items-center justify-center rounded bg-stone-800 text-base">
+                  {{ p.icon ?? '🎵' }}
+                </span>
+                <span class="min-w-0 flex-1 truncate text-sm text-stone-100">{{ p.name }}</span>
+                <span class="shrink-0 text-xs text-stone-500">{{ p.track_count }}</span>
+              </button>
+            </section>
+
+            <div
+              v-if="query.length >= 2 && !tracks.length && !albums.length && !artists.length && !playlists.length"
+              class="px-1 py-10 text-center text-sm text-stone-600"
+            >
+              No results for “{{ query }}”.
+            </div>
+          </template>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, ref, watch } from "vue";
+import { useLibraryStore } from "../stores/library";
+import { usePlaylistStore } from "../stores/playlists";
+import FeatherIcon from "@shared/components/FeatherIcon.vue";
+import type { CatalogTrack, AlbumGridItem } from "../types";
+
+const props = defineProps<{ open: boolean }>();
+const emit = defineEmits<{
+  close: [];
+  "open-album": [item: AlbumGridItem];
+}>();
+
+const lib = useLibraryStore();
+const playlistStore = usePlaylistStore();
+
+const query = ref("");
+const inputRef = ref<HTMLInputElement | null>(null);
+
+const RECENT_KEY = "muorg-web-recent-searches";
+const recentSearches = ref<string[]>(loadRecent());
+
+function loadRecent(): string[] {
+  try {
+    const v = JSON.parse(localStorage.getItem(RECENT_KEY) ?? "[]");
+    return Array.isArray(v) ? v.filter((x): x is string => typeof x === "string").slice(0, 5) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveRecent(q: string): void {
+  const next = [q, ...recentSearches.value.filter((s) => s !== q)].slice(0, 5);
+  recentSearches.value = next;
+  localStorage.setItem(RECENT_KEY, JSON.stringify(next));
+}
+
+function clearRecent(): void {
+  recentSearches.value = [];
+  localStorage.removeItem(RECENT_KEY);
+}
+
+const q = computed(() => query.value.trim().toLowerCase());
+
+const tracks = computed(() => {
+  if (q.value.length < 2) return [];
+  return lib.tracks
+    .filter(
+      (t) =>
+        (t.title ?? "").toLowerCase().includes(q.value) ||
+        (t.artist ?? "").toLowerCase().includes(q.value) ||
+        (t.album ?? "").toLowerCase().includes(q.value) ||
+        (t.album_artist ?? "").toLowerCase().includes(q.value),
+    )
+    .slice(0, 12);
+});
+
+const albums = computed(() => {
+  if (q.value.length < 2) return [];
+  return lib.albumGridItems
+    .filter(
+      (a) =>
+        a.album.toLowerCase().includes(q.value) || a.albumArtist.toLowerCase().includes(q.value),
+    )
+    .slice(0, 10);
+});
+
+const artists = computed(() => {
+  if (q.value.length < 2) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const t of lib.tracks) {
+    const name = (t.artist ?? t.album_artist ?? "").trim();
+    if (name && name.toLowerCase().includes(q.value) && !seen.has(name)) {
+      seen.add(name);
+      out.push(name);
+      if (out.length >= 8) break;
+    }
+  }
+  return out;
+});
+
+const playlists = computed(() => {
+  if (q.value.length < 2) return [];
+  return playlistStore.playlists
+    .filter((p) => p.name.toLowerCase().includes(q.value))
+    .slice(0, 8);
+});
+
+function albumCover(a: AlbumGridItem): string | undefined {
+  if (!a.hasCover || a.coverTrackId === null) return undefined;
+  lib.requestCover(a.coverTrackId);
+  return lib.coverCache.get(a.coverTrackId) ?? undefined;
+}
+
+function playTrack(t: CatalogTrack): void {
+  saveRecent(query.value.trim());
+  lib.playTrack(t);
+  close();
+}
+
+function openAlbum(a: AlbumGridItem): void {
+  saveRecent(query.value.trim());
+  emit("open-album", a);
+  close();
+}
+
+function openArtist(name: string): void {
+  saveRecent(query.value.trim());
+  lib.searchQuery = name;
+  lib.setGroupBy("artist");
+  lib.setViewMode("table");
+  close();
+}
+
+function openPlaylist(id: number): void {
+  saveRecent(query.value.trim());
+  playlistStore.selectPlaylist(id);
+  close();
+}
+
+function close(): void {
+  query.value = "";
+  emit("close");
+}
+
+watch(
+  () => props.open,
+  (open) => {
+    if (open) {
+      nextTick(() => inputRef.value?.focus());
+    } else {
+      query.value = "";
+    }
+  },
+);
+</script>

--- a/web-client/src/components/MobileTabBar.vue
+++ b/web-client/src/components/MobileTabBar.vue
@@ -1,0 +1,41 @@
+<template>
+  <nav
+    class="safe-bottom flex shrink-0 items-stretch justify-around border-t border-stone-700 bg-stone-900/95 px-2 pt-1 backdrop-blur md:hidden"
+    aria-label="Primary"
+  >
+    <button
+      v-for="tab in tabs"
+      :key="tab.id"
+      type="button"
+      class="flex min-h-11 flex-1 flex-col items-center justify-center gap-0.5 rounded-t-lg px-1 py-1 transition-colors active:bg-stone-800/60"
+      :class="active === tab.id ? 'text-stone-100' : 'text-stone-500'"
+      :aria-label="tab.label"
+      @click="emit('select', tab.id)"
+    >
+      <span
+        class="flex items-center gap-1.5 rounded-full px-3.5 py-1.5 transition-colors"
+        :class="active === tab.id ? 'border border-accent bg-accent/15 text-stone-100' : 'border border-transparent'"
+      >
+        <FeatherIcon :name="tab.icon" class="h-4 w-4" />
+        <span class="text-xs font-medium">{{ tab.label }}</span>
+      </span>
+    </button>
+  </nav>
+</template>
+
+<script setup lang="ts">
+import FeatherIcon from "@shared/components/FeatherIcon.vue";
+
+export type MobileTab = "music" | "albums" | "playlists" | "now-playing";
+
+defineProps<{ active: MobileTab }>();
+
+const emit = defineEmits<{ select: [tab: MobileTab] }>();
+
+const tabs: { id: MobileTab; label: string; icon: string }[] = [
+  { id: "music", label: "Music", icon: "music" },
+  { id: "albums", label: "Albums", icon: "disc" },
+  { id: "playlists", label: "Playlists", icon: "layers" },
+  { id: "now-playing", label: "Playing", icon: "play-circle" },
+];
+</script>

--- a/web-client/src/components/PlayerBar.vue
+++ b/web-client/src/components/PlayerBar.vue
@@ -6,7 +6,7 @@
     <!-- Mobile-only: progress bar row above main controls -->
     <div class="flex items-center gap-2 pb-1.5 sm:hidden">
       <span class="w-8 shrink-0 text-right text-xs tabular-nums text-stone-500">{{ currentTimeLabel }}</span>
-      <div class="relative min-w-0 flex-1 cursor-pointer py-2" @pointerdown.prevent="seekByClick">
+      <div class="relative min-h-6 min-w-0 flex-1 cursor-pointer" @pointerdown.prevent="seekByClick">
         <div class="h-1.5 w-full overflow-hidden rounded-full bg-stone-600">
           <div class="h-full rounded-full bg-accent transition-none" :style="{ width: progressPercent + '%' }" />
         </div>
@@ -90,50 +90,50 @@
       <div class="flex shrink-0 items-center gap-0.5 sm:hidden">
         <button
           type="button"
-          class="flex items-center justify-center rounded p-2 text-stone-400 hover:bg-stone-700 hover:text-stone-200"
+          class="flex h-10 w-10 items-center justify-center rounded text-stone-400 active:bg-stone-700 active:text-stone-200"
           aria-label="Restart"
-          @click="restart"
+          @click="restart; haptic()"
         >
           <FeatherIcon name="square" class="h-4 w-4" />
         </button>
         <button
           type="button"
-          class="flex items-center justify-center rounded p-2 text-stone-400 hover:bg-stone-700 hover:text-stone-200"
+          class="flex h-10 w-10 items-center justify-center rounded text-stone-400 active:bg-stone-700 active:text-stone-200"
           aria-label="Previous track"
-          @click="playPrevious()"
+          @click="playPrevious(); haptic()"
         >
           <FeatherIcon name="skip-back" class="h-5 w-5" />
         </button>
         <button
           type="button"
-          class="flex items-center justify-center rounded bg-accent p-2 text-stone-50 hover:bg-[var(--accent-hover)]"
+          class="flex h-10 w-10 items-center justify-center rounded-full bg-accent text-stone-50 active:bg-[var(--accent-hover)]"
           :aria-label="lib.isPlaying ? 'Pause' : 'Play'"
-          @click="lib.togglePlayPause()"
+          @click="lib.togglePlayPause(); haptic()"
         >
           <FeatherIcon :name="lib.isPlaying ? 'pause' : 'play'" class="h-5 w-5" />
         </button>
         <button
           type="button"
-          class="flex items-center justify-center rounded p-2 text-stone-400 hover:bg-stone-700 hover:text-stone-200"
+          class="flex h-10 w-10 items-center justify-center rounded text-stone-400 active:bg-stone-700 active:text-stone-200"
           aria-label="Next track"
-          @click="playNext()"
+          @click="playNext(); haptic()"
         >
           <FeatherIcon name="skip-forward" class="h-5 w-5" />
         </button>
         <button
           type="button"
-          class="flex items-center justify-center rounded p-2 hover:bg-stone-700 hover:text-stone-200"
+          class="flex h-10 w-10 items-center justify-center rounded active:bg-stone-700 active:text-stone-200"
           :class="shuffle ? 'text-accent' : 'text-stone-400'"
           aria-label="Shuffle"
-          @click="shuffle = !shuffle"
+          @click="shuffle = !shuffle; haptic()"
         >
           <FeatherIcon name="shuffle" class="h-4 w-4" />
         </button>
         <button
           type="button"
-          class="flex items-center justify-center rounded p-2 text-stone-400 hover:bg-stone-700 hover:text-stone-200"
+          class="flex h-10 w-10 items-center justify-center rounded text-stone-400 active:bg-stone-700 active:text-stone-200"
           aria-label="Expand player"
-          @click="showOverlay = true"
+          @click="showOverlay = true; haptic()"
         >
           <FeatherIcon name="maximize-2" class="h-4 w-4" />
         </button>
@@ -229,105 +229,125 @@
           </template>
         </div>
 
-        <!-- Cover art -->
-        <div class="relative z-10 flex flex-1 items-center justify-center px-8 pt-8">
-          <div class="aspect-square w-full max-w-sm overflow-hidden rounded-2xl shadow-2xl">
-            <img v-if="coverUrl" :src="coverUrl" class="h-full w-full object-cover" />
-            <div v-else class="flex h-full w-full items-center justify-center bg-stone-800">
-              <FeatherIcon name="music" class="h-16 w-16 text-stone-600" />
-            </div>
-          </div>
-        </div>
-
-        <!-- Bottom controls -->
-        <div class="relative z-10 flex flex-col gap-4 px-3 pt-6" style="padding-bottom: max(env(safe-area-inset-bottom, 0px), 0.75rem)">
-          <!-- Track info -->
-          <div class="text-center">
-            <p class="truncate text-xl font-bold text-stone-100">{{ lib.nowPlaying.title ?? '—' }}</p>
-            <p class="truncate text-stone-400">{{ lib.nowPlaying.artist ?? lib.nowPlaying.album_artist ?? '—' }}</p>
-            <p class="truncate text-sm text-stone-600">{{ lib.nowPlaying.album }}</p>
-          </div>
-
-          <!-- Progress bar row -->
-          <div class="flex items-center gap-3">
-            <span class="w-9 shrink-0 text-right text-xs tabular-nums text-stone-500">{{ currentTimeLabel }}</span>
-            <div class="relative min-w-0 flex-1 cursor-pointer" @click="seekByClick">
-              <div class="h-2 w-full overflow-hidden rounded-full bg-stone-700">
-                <div class="h-full rounded-full bg-accent transition-none" :style="{ width: progressPercent + '%' }" />
+        <!-- Draggable content: swipe down to dismiss -->
+        <div
+          class="relative z-10 flex min-h-0 flex-1 flex-col landscape:md:flex-row"
+          :style="{ transform: `translateY(${dragY}px)`, transition: dragTracking ? 'none' : 'transform 0.25s ease-out' }"
+          @touchstart.passive="onOverlayTouchStart"
+          @touchmove.passive="onOverlayTouchMove"
+          @touchend="onOverlayTouchEnd"
+          @touchcancel="onOverlayTouchEnd"
+        >
+          <!-- Cover art -->
+          <div class="relative flex flex-1 items-center justify-center px-8 pt-8 landscape:md:w-1/2 landscape:md:pt-0">
+            <div class="aspect-square w-full max-w-sm overflow-hidden rounded-2xl shadow-2xl">
+              <img v-if="coverUrl" :src="coverUrl" class="h-full w-full object-cover" />
+              <div v-else class="flex h-full w-full items-center justify-center bg-stone-800">
+                <FeatherIcon name="music" class="h-16 w-16 text-stone-600" />
               </div>
             </div>
-            <span class="w-9 shrink-0 text-xs tabular-nums text-stone-500">{{ durationLabel }}</span>
           </div>
 
-          <!-- Main controls: restart | prev | play/pause | next | shuffle -->
-          <div class="flex items-center justify-center gap-1">
-            <button
-              class="flex items-center justify-center rounded p-2 text-stone-400 hover:bg-stone-800 hover:text-stone-200"
-              title="Restart"
-              @click="restart"
-            >
-              <FeatherIcon name="square" class="h-5 w-5" />
-            </button>
-            <button
-              class="flex items-center justify-center rounded p-2 text-stone-400 hover:bg-stone-800 hover:text-stone-200"
-              @click="playPrevious()"
-            >
-              <FeatherIcon name="skip-back" class="h-5 w-5" />
-            </button>
-            <button
-              class="flex items-center justify-center rounded bg-accent p-2 text-stone-50 hover:bg-[var(--accent-hover)]"
-              @click="lib.togglePlayPause()"
-            >
-              <FeatherIcon :name="lib.isPlaying ? 'pause' : 'play'" class="h-5 w-5" />
-            </button>
-            <button
-              class="flex items-center justify-center rounded p-2 text-stone-400 hover:bg-stone-800 hover:text-stone-200"
-              @click="playNext()"
-            >
-              <FeatherIcon name="skip-forward" class="h-5 w-5" />
-            </button>
-          </div>
+          <!-- Bottom controls -->
+          <div class="relative flex flex-col gap-4 px-3 pt-6 landscape:md:w-1/2 landscape:md:justify-center" style="padding-bottom: max(env(safe-area-inset-bottom, 0px), 0.75rem)">
+            <!-- Track info -->
+            <div class="text-center landscape:md:text-left">
+              <p class="truncate text-xl font-bold text-stone-100">{{ lib.nowPlaying.title ?? '—' }}</p>
+              <p class="truncate text-stone-400">{{ lib.nowPlaying.artist ?? lib.nowPlaying.album_artist ?? '—' }}</p>
+              <p class="truncate text-sm text-stone-600">{{ lib.nowPlaying.album }}</p>
+            </div>
 
-          <!-- Secondary controls: repeat | volume | shuffle | minimize -->
-          <div class="flex items-center gap-1">
-            <button
-              class="relative flex items-center justify-center rounded p-2 hover:bg-stone-800 hover:text-stone-200"
-              :class="repeat !== 'none' ? 'text-accent' : 'text-stone-400'"
-              title="Repeat"
-              @click="cycleRepeat"
-            >
-              <FeatherIcon name="repeat" class="h-5 w-5" />
-              <span v-if="repeat === 'one'" class="absolute bottom-0.5 right-0.5 text-[8px] font-bold leading-none">1</span>
-            </button>
-            <button
-              class="flex items-center justify-center rounded p-2 text-stone-400 hover:bg-stone-800 hover:text-stone-200"
-              title="Toggle mute"
-              @click="toggleMute"
-            >
-              <FeatherIcon :name="lib.volume === 0 ? 'volume-x' : lib.volume < 0.5 ? 'volume-1' : 'volume-2'" class="h-5 w-5" />
-            </button>
-            <input
-              type="range" min="0" max="1" step="0.02"
-              :value="lib.volume"
-              class="player-volume-slider min-w-0 flex-1"
-              :style="{ '--volume-percent': (lib.volume * 100) + '%' }"
-              @input="lib.setVolume(parseFloat(($event.target as HTMLInputElement).value))"
-            />
-            <button
-              class="flex shrink-0 items-center justify-center rounded p-2 hover:bg-stone-800 hover:text-stone-200"
-              :class="shuffle ? 'text-accent' : 'text-stone-400'"
-              title="Shuffle"
-              @click="shuffle = !shuffle"
-            >
-              <FeatherIcon name="shuffle" class="h-5 w-5" />
-            </button>
-            <button
-              class="flex shrink-0 items-center justify-center rounded p-2 text-stone-400 hover:bg-stone-800 hover:text-stone-200"
-              title="Minimize player"
-              @click="showOverlay = false"
-            >
-              <FeatherIcon name="minimize-2" class="h-5 w-5" />
-            </button>
+            <!-- Progress bar row (draggable seek with visible thumb) -->
+            <div class="flex items-center gap-3">
+              <span class="w-9 shrink-0 text-right text-xs tabular-nums text-stone-500">{{ currentTimeLabel }}</span>
+              <div
+                class="overlay-seekbar relative flex h-8 min-w-0 flex-1 cursor-pointer items-center touch-none"
+                @pointerdown="onSeekPointerDown"
+                @pointermove="onSeekPointerMove"
+                @pointerup="onSeekPointerUp"
+                @pointercancel="onSeekPointerUp"
+              >
+                <div class="h-1.5 w-full overflow-hidden rounded-full bg-stone-700">
+                  <div class="h-full rounded-full bg-accent" :style="{ width: seekDisplayPercent + '%' }" />
+                </div>
+                <div
+                  class="absolute h-4 w-4 -translate-x-1/2 rounded-full bg-accent shadow-md"
+                  :style="{ left: seekDisplayPercent + '%' }"
+                />
+              </div>
+              <span class="w-9 shrink-0 text-xs tabular-nums text-stone-500">{{ durationLabel }}</span>
+            </div>
+
+            <!-- Main controls: restart | prev | play/pause | next -->
+            <div class="flex items-center justify-center gap-1 landscape:md:justify-start">
+              <button
+                class="flex h-12 w-12 items-center justify-center rounded-full text-stone-400 active:bg-stone-800 active:text-stone-200"
+                title="Restart"
+                @click="restart; haptic()"
+              >
+                <FeatherIcon name="square" class="h-5 w-5" />
+              </button>
+              <button
+                class="flex h-12 w-12 items-center justify-center rounded-full text-stone-400 active:bg-stone-800 active:text-stone-200"
+                @click="playPrevious(); haptic()"
+              >
+                <FeatherIcon name="skip-back" class="h-5 w-5" />
+              </button>
+              <button
+                class="mx-1 flex h-14 w-14 items-center justify-center rounded-full bg-accent text-stone-50 shadow-lg active:bg-[var(--accent-hover)]"
+                @click="lib.togglePlayPause(); haptic()"
+              >
+                <FeatherIcon :name="lib.isPlaying ? 'pause' : 'play'" class="h-6 w-6" />
+              </button>
+              <button
+                class="flex h-12 w-12 items-center justify-center rounded-full text-stone-400 active:bg-stone-800 active:text-stone-200"
+                @click="playNext(); haptic()"
+              >
+                <FeatherIcon name="skip-forward" class="h-5 w-5" />
+              </button>
+            </div>
+
+            <!-- Secondary controls: repeat | volume | shuffle | minimize -->
+            <div class="flex items-center gap-1 landscape:md:justify-start">
+              <button
+                class="relative flex h-11 w-11 items-center justify-center rounded-full active:bg-stone-800 active:text-stone-200"
+                :class="repeat !== 'none' ? 'text-accent' : 'text-stone-400'"
+                title="Repeat"
+                @click="cycleRepeat(); haptic()"
+              >
+                <FeatherIcon name="repeat" class="h-5 w-5" />
+                <span v-if="repeat === 'one'" class="absolute bottom-0.5 right-0.5 text-[8px] font-bold leading-none">1</span>
+              </button>
+              <button
+                class="flex h-11 w-11 items-center justify-center rounded-full text-stone-400 active:bg-stone-800 active:text-stone-200"
+                title="Toggle mute"
+                @click="toggleMute(); haptic()"
+              >
+                <FeatherIcon :name="lib.volume === 0 ? 'volume-x' : lib.volume < 0.5 ? 'volume-1' : 'volume-2'" class="h-5 w-5" />
+              </button>
+              <input
+                type="range" min="0" max="1" step="0.02"
+                :value="lib.volume"
+                class="player-volume-slider min-w-0 flex-1"
+                :style="{ '--volume-percent': (lib.volume * 100) + '%' }"
+                @input="lib.setVolume(parseFloat(($event.target as HTMLInputElement).value))"
+              />
+              <button
+                class="flex h-11 w-11 shrink-0 items-center justify-center rounded-full active:bg-stone-800 active:text-stone-200"
+                :class="shuffle ? 'text-accent' : 'text-stone-400'"
+                title="Shuffle"
+                @click="shuffle = !shuffle; haptic()"
+              >
+                <FeatherIcon name="shuffle" class="h-5 w-5" />
+              </button>
+              <button
+                class="flex h-11 w-11 shrink-0 items-center justify-center rounded-full text-stone-400 active:bg-stone-800 active:text-stone-200"
+                title="Minimize player"
+                @click="showOverlay = false; haptic()"
+              >
+                <FeatherIcon name="minimize-2" class="h-5 w-5" />
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -366,7 +386,13 @@ import { useDominantColor, useEdgeColors, getGlowBlobs, isColorBland, hasOpposin
 
 const lib = useLibraryStore();
 const playlistStore = usePlaylistStore();
-const showOverlay = ref(false);
+
+const props = defineProps<{ overlayOpen: boolean }>();
+const emit = defineEmits<{ "update:overlayOpen": [v: boolean] }>();
+const showOverlay = computed({
+  get: () => props.overlayOpen,
+  set: (v: boolean) => emit("update:overlayOpen", v),
+});
 
 // Context menu on the now-playing track info
 const nowPlayingCtxRef = ref<InstanceType<typeof TrackContextMenu> | null>(null);
@@ -461,6 +487,74 @@ function seekByClick(e: PointerEvent | MouseEvent): void {
   const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
   const ratio = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
   lib.seekTo(Math.floor(ratio * lib.durationSecs));
+}
+
+// ── Overlay: draggable seek bar (visible thumb) ──────────────────────────
+const seeking = ref(false);
+const seekPreview = ref<number | null>(null);
+
+const seekDisplayPercent = computed(() => {
+  if (seeking.value && seekPreview.value !== null) return seekPreview.value;
+  return progressPercent.value;
+});
+
+function seekFromEvent(e: PointerEvent): number {
+  const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+  const ratio = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
+  return Math.floor(ratio * lib.durationSecs);
+}
+
+function onSeekPointerDown(e: PointerEvent): void {
+  if (e.pointerType === "mouse" && e.button !== 0) return;
+  seeking.value = true;
+  (e.currentTarget as HTMLElement).setPointerCapture?.(e.pointerId);
+  seekPreview.value = (progressPercent.value / 100) * 100;
+  const secs = seekFromEvent(e);
+  seekPreview.value = lib.durationSecs ? (secs / lib.durationSecs) * 100 : 0;
+}
+
+function onSeekPointerMove(e: PointerEvent): void {
+  if (!seeking.value) return;
+  const secs = seekFromEvent(e);
+  seekPreview.value = lib.durationSecs ? (secs / lib.durationSecs) * 100 : 0;
+}
+
+function onSeekPointerUp(e: PointerEvent): void {
+  if (!seeking.value) return;
+  seeking.value = false;
+  const secs = seekFromEvent(e);
+  lib.seekTo(secs);
+  seekPreview.value = null;
+}
+
+// ── Overlay: swipe down to dismiss ───────────────────────────────────────
+const dragY = ref(0);
+const dragTracking = ref(false);
+let dragStartY = 0;
+let dragFromSeekbar = false;
+
+function onOverlayTouchStart(e: TouchEvent): void {
+  dragTracking.value = true;
+  dragStartY = e.touches[0].clientY;
+  dragFromSeekbar = (e.target as HTMLElement).closest(".overlay-seekbar") !== null;
+}
+
+function onOverlayTouchMove(e: TouchEvent): void {
+  if (!dragTracking.value || dragFromSeekbar) return;
+  const dy = e.touches[0].clientY - dragStartY;
+  dragY.value = dy > 0 ? dy * 0.5 : 0;
+}
+
+function onOverlayTouchEnd(): void {
+  if (!dragTracking.value) return;
+  dragTracking.value = false;
+  if (dragY.value > 110) showOverlay.value = false;
+  dragY.value = 0;
+}
+
+// ── Haptics (mobile only) ────────────────────────────────────────────────
+function haptic(): void {
+  if ("vibrate" in navigator) navigator.vibrate?.(8);
 }
 
 function toggleMute(): void {

--- a/web-client/src/components/PlaylistSidebar.vue
+++ b/web-client/src/components/PlaylistSidebar.vue
@@ -2,10 +2,10 @@
   <aside
     :class="[
       'relative z-40 flex flex-col border-r border-stone-800 bg-stone-800/80 transition-all duration-200',
-      open ? 'w-52' : 'w-0 overflow-hidden',
+      open ? 'w-[85vw] max-w-xs md:w-52' : 'w-0 overflow-hidden',
     ]"
   >
-    <div class="flex min-w-0 flex-col overflow-hidden" style="width: 208px;">
+    <div class="flex min-w-0 flex-col overflow-hidden w-full">
       <!-- Sidebar header -->
       <div class="flex shrink-0 items-center border-b border-stone-700 px-3 py-2">
         <span class="text-xs font-semibold uppercase tracking-wide text-stone-500">Playlists</span>
@@ -15,7 +15,7 @@
         <div class="mb-1 flex flex-col gap-1">
           <button
             type="button"
-            class="flex w-full items-center gap-2 rounded border border-stone-600 bg-stone-700 px-3 py-2 text-left text-sm text-stone-200 hover:bg-stone-600"
+            class="flex w-full items-center gap-2 rounded border border-stone-600 bg-stone-700 px-3 py-2.5 text-left text-sm text-stone-200 hover:bg-stone-600 active:bg-stone-600 md:py-2"
             @click="showCreateModal = true"
           >
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="h-4 w-4 shrink-0 text-stone-400">
@@ -25,7 +25,7 @@
           </button>
           <button
             type="button"
-            class="flex w-full items-center gap-2 rounded border border-stone-700 bg-stone-800 px-3 py-2 text-left text-sm text-stone-400 hover:bg-stone-700 hover:text-stone-200"
+            class="flex w-full items-center gap-2 rounded border border-stone-700 bg-stone-800 px-3 py-2.5 text-left text-sm text-stone-400 hover:bg-stone-700 hover:text-stone-200 active:bg-stone-700 md:py-2"
             @click="showSmartEditor = true"
           >
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="h-4 w-4 shrink-0 text-stone-500">
@@ -37,7 +37,7 @@
 
         <button
           type="button"
-          class="flex w-full items-center gap-2 rounded border px-1.5 py-1.5 text-left text-sm transition-colors"
+          class="flex w-full items-center gap-2 rounded border px-2 py-2.5 text-left text-sm transition-colors md:py-1.5"
           :class="activeId === null ? 'border-stone-500 bg-stone-700 text-stone-100' : 'border-transparent text-stone-400 hover:bg-stone-700/50 hover:text-stone-200'"
           @click="select(null)"
         >
@@ -60,7 +60,7 @@
           >
             <button
               type="button"
-              class="flex min-w-0 flex-1 items-center gap-2 truncate px-1.5 py-1.5 text-left"
+              class="flex min-w-0 flex-1 items-center gap-2 truncate px-2 py-2.5 text-left md:py-1.5"
               @click="select(p.id)"
             >
               <span class="shrink-0 text-base leading-none">{{ p.icon || '🎵' }}</span>
@@ -88,12 +88,14 @@
         v-if="ctxMenu"
         ref="ctxMenuRef"
         class="fixed z-[300] min-w-[140px] rounded-lg border border-stone-600 bg-stone-800 py-1 shadow-xl"
+        :class="isMobile ? 'ctx-sheet' : ''"
         :style="{ left: ctxMenu.x + 'px', top: ctxMenu.y + 'px' }"
         @click.stop
       >
+        <div class="ctx-sheet-handle" />
         <button
           type="button"
-          class="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-stone-200 hover:bg-stone-700 hover:text-stone-50"
+          class="flex w-full items-center gap-2 px-3 py-2.5 text-left text-sm text-stone-200 hover:bg-stone-700 hover:text-stone-50 active:bg-stone-700 md:py-2"
           @click="select(ctxMenu.playlist.id); ctxMenu = null"
         >
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="h-4 w-4 shrink-0 text-stone-400">
@@ -107,7 +109,7 @@
         <button
           v-if="ctxMenu.playlist.smart_rules"
           type="button"
-          class="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-stone-200 hover:bg-stone-700 hover:text-stone-50"
+          class="flex w-full items-center gap-2 px-3 py-2.5 text-left text-sm text-stone-200 hover:bg-stone-700 hover:text-stone-50 active:bg-stone-700 md:py-2"
           @click="editSmartRules(ctxMenu.playlist); ctxMenu = null"
         >
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="h-4 w-4 shrink-0 text-stone-400">
@@ -118,7 +120,7 @@
 
         <button
           type="button"
-          class="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-stone-200 hover:bg-stone-700 hover:text-stone-50"
+          class="flex w-full items-center gap-2 px-3 py-2.5 text-left text-sm text-stone-200 hover:bg-stone-700 hover:text-stone-50 active:bg-stone-700 md:py-2"
           @click="startRename(ctxMenu.playlist); ctxMenu = null"
         >
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="h-4 w-4 shrink-0 text-stone-400">
@@ -128,7 +130,7 @@
         </button>
         <button
           type="button"
-          class="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-red-400 hover:bg-stone-700 hover:text-red-300"
+          class="flex w-full items-center gap-2 px-3 py-2.5 text-left text-sm text-red-400 hover:bg-stone-700 hover:text-red-300 active:bg-stone-700 md:py-2"
           @click="deletePlaylist(ctxMenu.playlist); ctxMenu = null"
         >
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="h-4 w-4 shrink-0">
@@ -197,6 +199,8 @@ import { usePlaylistStore } from "../stores/playlists";
 import type { Playlist, SmartRule } from "../types";
 
 defineProps<{ open: boolean }>();
+
+const isMobile = computed(() => window.matchMedia("(max-width: 639px)").matches);
 
 const store = usePlaylistStore();
 const playlists = computed(() => store.playlists);

--- a/web-client/src/components/TrackContextMenu.vue
+++ b/web-client/src/components/TrackContextMenu.vue
@@ -5,8 +5,10 @@
       v-if="visible"
       ref="menuEl"
       class="ctx-menu"
+      :class="isMobile ? 'ctx-sheet' : ''"
       :style="{ top: y + 'px', left: x + 'px' }"
     >
+      <div class="ctx-sheet-handle" />
       <button class="ctx-menu-item" @click.stop="emit('play'); close()">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
           <polygon points="5 3 19 12 5 21 5 3" />
@@ -91,6 +93,8 @@ const y = ref(0);
 let openedAt = 0;
 const menuEl = ref<HTMLElement | null>(null);
 const membershipIds = ref<Set<number> | null>(null);
+
+const isMobile = computed(() => window.matchMedia("(max-width: 639px)").matches);
 
 const playlistsIn = computed(() =>
   membershipIds.value === null

--- a/web-client/src/components/TrackRow.vue
+++ b/web-client/src/components/TrackRow.vue
@@ -14,8 +14,60 @@
     @touchmove.passive="onTouchMove"
     @touchend="onTouchEnd"
   >
+    <!-- ── Phone (< sm): swipeable flex row ───────────────────────────── -->
+    <td colspan="7" class="relative overflow-hidden p-0 sm:hidden" style="touch-action: pan-y">
+      <!-- Revealed action buttons (behind the sliding content) -->
+      <div class="absolute inset-y-0 right-0 flex" style="width: 168px">
+        <button
+          type="button"
+          class="flex min-w-0 flex-1 flex-col items-center justify-center gap-0.5 bg-accent text-[11px] font-medium text-white active:bg-[var(--accent-hover)]"
+          @click.stop="swipeQueue"
+        >
+          <FeatherIcon name="plus" class="h-4 w-4" />
+          Queue
+        </button>
+        <button
+          type="button"
+          class="flex min-w-0 flex-1 flex-col items-center justify-center gap-0.5 bg-stone-600 text-[11px] font-medium text-stone-100 active:bg-stone-500"
+          @click.stop="swipePlaylist"
+        >
+          <FeatherIcon name="list" class="h-4 w-4" />
+          Playlist
+        </button>
+      </div>
+
+      <!-- Sliding row content -->
+      <div
+        class="relative z-10 flex items-center gap-1 py-2 pl-1.5 pr-1"
+        :class="isPlaying ? 'row-playing' : isSelected ? 'bg-stone-700/30' : 'bg-stone-900'"
+        :style="swipeStyle"
+      >
+        <label
+          class="flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center rounded border border-stone-600"
+          :class="isSelected ? 'bg-accent border-accent' : ''"
+          @click.stop="lib.toggleTrackSelection(track.id, false)"
+        >
+          <svg v-if="isSelected" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3">
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
+        </label>
+        <div class="min-w-0 flex-1 px-1">
+          <p class="truncate text-sm font-medium text-stone-200">
+            <span v-if="track.track_number" class="mr-1.5 text-xs font-normal text-stone-500">{{ track.track_number }}</span>{{ track.title ?? '—' }}
+          </p>
+          <p class="truncate text-xs text-stone-500">{{ track.artist ?? track.album_artist ?? '—' }}</p>
+        </div>
+        <span
+          class="shrink-0 rounded border px-1 py-0.5 font-mono text-[10px] uppercase leading-none tracking-wider"
+          :class="track.format === 'flac' ? 'border-accent/70 text-accent' : 'border-stone-600 text-stone-500'"
+        >{{ track.format }}</span>
+        <span class="shrink-0 pr-1 text-right text-xs text-stone-500 whitespace-nowrap">{{ duration }}</span>
+      </div>
+    </td>
+
+    <!-- ── Desktop (≥ sm): original table cells ───────────────────────── -->
     <!-- Checkbox + cover art column -->
-    <td :class="lib.tableArtSize === 'large' ? 'w-28 py-1.5 pl-3 pr-2' : 'w-px py-1 pl-1.5 pr-1 sm:w-10 sm:py-1.5 sm:pl-3 sm:pr-2'">
+    <td :class="lib.tableArtSize === 'large' ? 'hidden sm:table-cell w-28 py-1.5 pl-3 pr-2' : 'hidden sm:table-cell w-px py-1 pl-1.5 pr-1 sm:w-10 sm:py-1.5 sm:pl-3 sm:pr-2'">
       <div class="flex items-center gap-1">
         <label
           class="checkbox-cell flex h-4 w-4 shrink-0 cursor-pointer items-center justify-center rounded border border-stone-600 hover:border-stone-400 sm:h-5 sm:w-5"
@@ -33,7 +85,7 @@
     </td>
 
     <!-- Title + track number + artist (stacked on mobile) -->
-    <td class="max-w-0 py-1.5 pr-4">
+    <td class="hidden sm:table-cell max-w-0 py-1.5 pr-4">
       <p class="truncate text-sm font-medium text-stone-200">
         <span v-if="track.track_number" class="mr-1.5 text-xs font-normal text-stone-500">{{ track.track_number }}</span>{{ track.title ?? '—' }}
       </p>
@@ -56,7 +108,7 @@
     </td>
 
     <!-- Format pill -->
-    <td class="py-1.5 pr-3 whitespace-nowrap">
+    <td class="hidden sm:table-cell py-1.5 pr-3 whitespace-nowrap">
       <span
         class="rounded border px-1 py-0.5 font-mono text-[10px] uppercase leading-none tracking-wider"
         :class="track.format === 'flac' ? 'border-accent/70 text-accent' : 'border-stone-600 text-stone-500'"
@@ -64,21 +116,23 @@
     </td>
 
     <!-- Duration -->
-    <td class="py-1.5 pr-3 text-right text-xs text-stone-500 whitespace-nowrap">
+    <td class="hidden sm:table-cell py-1.5 pr-3 text-right text-xs text-stone-500 whitespace-nowrap">
       {{ duration }}
     </td>
   </tr>
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import { useLibraryStore, formatDuration } from "../stores/library";
+import FeatherIcon from "@shared/components/FeatherIcon.vue";
 import type { CatalogTrack } from "../types";
 
 const props = defineProps<{ track: CatalogTrack }>();
 const emit = defineEmits<{
   play: [];
   contextmenu: [event: { clientX: number; clientY: number }];
+  "add-to-playlist": [track: CatalogTrack];
 }>();
 
 const lib = useLibraryStore();
@@ -100,6 +154,69 @@ function handleShiftClick(): void {
   lib.toggleTrackSelection(props.track.id, true);
 }
 
+// ── Swipe actions (touch devices only, phones) ───────────────────────────
+const SWIPE_REVEAL = 168;
+const isTouch = typeof window !== "undefined" && "ontouchstart" in window;
+
+const offset = ref(0);
+const open = ref(false);
+let swiping = false;
+let startX = 0;
+let startY = 0;
+
+const swipeEnabled = computed(() => isTouch && lib.selectedTrackIds.size === 0);
+
+const swipeStyle = computed(() => ({
+  transform: `translateX(${offset.value}px)`,
+  transition: swiping ? "none" : "transform 0.22s cubic-bezier(0.16, 1, 0.3, 1)",
+}));
+
+function onSwipeStart(e: TouchEvent): void {
+  if (!swipeEnabled.value) return;
+  swiping = true;
+  startX = e.touches[0].clientX;
+  startY = e.touches[0].clientY;
+}
+
+function onSwipeMove(e: TouchEvent): void {
+  if (!swiping) return;
+  const t = e.touches[0];
+  const dx = t.clientX - startX;
+  const dy = t.clientY - startY;
+  if (Math.abs(dy) > Math.abs(dx) && Math.abs(dy) > 10) {
+    // Vertical scroll — hand back to the browser
+    swiping = false;
+    offset.value = open.value ? -SWIPE_REVEAL : 0;
+    return;
+  }
+  const base = open.value ? -SWIPE_REVEAL : 0;
+  offset.value = Math.max(-SWIPE_REVEAL, Math.min(0, base + dx));
+}
+
+function onSwipeEnd(): void {
+  if (!swiping) return;
+  swiping = false;
+  open.value = offset.value < -SWIPE_REVEAL / 2;
+  offset.value = open.value ? -SWIPE_REVEAL : 0;
+  if (open.value) navigator.vibrate?.(10);
+}
+
+function closeSwipe(): void {
+  open.value = false;
+  offset.value = 0;
+}
+
+function swipeQueue(): void {
+  lib.addToQueue(props.track);
+  closeSwipe();
+  navigator.vibrate?.(8);
+}
+
+function swipePlaylist(): void {
+  closeSwipe();
+  emit("add-to-playlist", props.track);
+}
+
 // ── Long-press → context menu ──────────────────────────────────────────────
 const LONG_PRESS_MS = 500;
 let _lpTimer: ReturnType<typeof setTimeout> | null = null;
@@ -107,6 +224,7 @@ let _lpStart = { x: 0, y: 0 };
 let _lpFired = false;
 
 function onTouchStart(e: TouchEvent): void {
+  onSwipeStart(e);
   _lpFired = false;
   const t = e.touches[0];
   _lpStart = { x: t.clientX, y: t.clientY };
@@ -119,6 +237,7 @@ function onTouchStart(e: TouchEvent): void {
 }
 
 function onTouchMove(e: TouchEvent): void {
+  onSwipeMove(e);
   if (!_lpTimer) return;
   const t = e.touches[0];
   if (Math.abs(t.clientX - _lpStart.x) > 8 || Math.abs(t.clientY - _lpStart.y) > 8) {
@@ -128,6 +247,7 @@ function onTouchMove(e: TouchEvent): void {
 }
 
 function onTouchEnd(e: TouchEvent): void {
+  onSwipeEnd();
   if (_lpTimer) { clearTimeout(_lpTimer); _lpTimer = null; }
   if (_lpFired) { e.preventDefault(); _lpFired = false; }
 }

--- a/web-client/src/components/TrackTable.vue
+++ b/web-client/src/components/TrackTable.vue
@@ -1,104 +1,134 @@
 <template>
   <div class="flex min-h-0 flex-1 flex-col overflow-hidden">
-    <div class="flex-1 overflow-auto">
-      <table class="w-full border-collapse text-left sm:min-w-[400px]">
-        <!-- Sticky header -->
-        <thead class="sticky top-0 z-10 bg-stone-900 text-xs uppercase tracking-wide text-stone-500">
-          <tr class="border-b border-stone-700">
-            <th :class="lib.tableArtSize === 'large' ? 'w-28 py-1 pl-3 pr-2' : 'w-px py-1 pl-1.5 pr-1 sm:w-10 sm:pl-3 sm:pr-2'">
-              <div class="flex items-center gap-0.5">
-                <label
-                  class="flex h-4 w-4 cursor-pointer items-center justify-center rounded border border-stone-600 hover:border-stone-400 sm:h-5 sm:w-5"
-                  :class="allSelected ? 'bg-accent border-accent' : ''"
-                  @click.stop="toggleSelectAll"
-                >
-                  <svg
-                    v-if="allSelected"
-                    width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3"
-                  >
-                    <polyline points="20 6 9 17 4 12" />
-                  </svg>
-                  <svg
-                    v-else-if="someSelected"
-                    width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"
-                  >
-                    <line x1="5" y1="12" x2="19" y2="12" />
-                  </svg>
-                </label>
-              </div>
-            </th>
-            <th
-              class="w-[35%] cursor-pointer py-2 pr-4 hover:text-stone-300 select-none"
-              @click="lib.setTableSort('title')"
-            >
-              Title <span v-if="lib.tableSortCol === 'title'" class="ml-0.5 inline-block text-accent">{{ lib.tableSortDir === 'asc' ? '↑' : '↓' }}</span>
-            </th>
-            <th
-              class="hidden w-[25%] cursor-pointer py-2 pr-4 hover:text-stone-300 select-none sm:table-cell"
-              @click="lib.setTableSort('artist')"
-            >
-              Artist <span v-if="lib.tableSortCol === 'artist'" class="ml-0.5 inline-block text-accent">{{ lib.tableSortDir === 'asc' ? '↑' : '↓' }}</span>
-            </th>
-            <th
-              class="hidden w-[25%] cursor-pointer py-2 pr-4 hover:text-stone-300 select-none md:table-cell"
-              @click="lib.setTableSort('album')"
-            >
-              Album <span v-if="lib.tableSortCol === 'album'" class="ml-0.5 inline-block text-accent">{{ lib.tableSortDir === 'asc' ? '↑' : '↓' }}</span>
-            </th>
-            <th
-              class="hidden w-16 cursor-pointer py-2 pr-4 hover:text-stone-300 select-none lg:table-cell"
-              @click="lib.setTableSort('year')"
-            >
-              Year <span v-if="lib.tableSortCol === 'year'" class="ml-0.5 inline-block text-accent">{{ lib.tableSortDir === 'asc' ? '↑' : '↓' }}</span>
-            </th>
-            <th class="w-14 py-2 pr-3" />
-            <th
-              class="w-16 cursor-pointer py-2 pr-3 text-right hover:text-stone-300 select-none"
-              @click="lib.setTableSort('duration')"
-            >
-              <span v-if="lib.tableSortCol === 'duration'" class="mr-0.5 inline-block text-accent">{{ lib.tableSortDir === 'asc' ? '↑' : '↓' }}</span>Time
-            </th>
-          </tr>
-        </thead>
+    <div ref="scrollEl" class="relative flex-1 overflow-auto overscroll-contain" @scroll="onScroll">
+      <!-- Pull-to-refresh indicator -->
+      <div class="pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center" :style="indicatorStyle">
+        <div class="mt-2 flex h-9 w-9 items-center justify-center rounded-full border border-stone-600 bg-stone-800 shadow-lg">
+          <FeatherIcon name="refresh-cw" class="h-4 w-4 text-accent" :class="ptr.refreshing ? 'animate-spin' : ''" />
+        </div>
+      </div>
 
-        <tbody>
-          <template v-if="lib.loading">
-            <tr>
-              <td colspan="7" class="py-8 text-center text-sm text-stone-500">Loading library…</td>
+      <div :style="{ transform: contentTransform }">
+        <table class="w-full border-collapse text-left sm:min-w-[400px]">
+          <!-- Sticky header -->
+          <thead class="sticky top-0 z-10 bg-stone-900 text-xs uppercase tracking-wide text-stone-500">
+            <tr class="border-b border-stone-700">
+              <th :class="lib.tableArtSize === 'large' ? 'w-28 py-1 pl-3 pr-2' : 'w-px py-1 pl-1.5 pr-1 sm:w-10 sm:pl-3 sm:pr-2'">
+                <div class="flex items-center gap-0.5">
+                  <label
+                    class="flex h-4 w-4 cursor-pointer items-center justify-center rounded border border-stone-600 hover:border-stone-400 sm:h-5 sm:w-5"
+                    :class="allSelected ? 'bg-accent border-accent' : ''"
+                    @click.stop="toggleSelectAll"
+                  >
+                    <svg
+                      v-if="allSelected"
+                      width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3"
+                    >
+                      <polyline points="20 6 9 17 4 12" />
+                    </svg>
+                    <svg
+                      v-else-if="someSelected"
+                      width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"
+                    >
+                      <line x1="5" y1="12" x2="19" y2="12" />
+                    </svg>
+                  </label>
+                </div>
+              </th>
+              <th
+                class="w-[35%] cursor-pointer py-2 pr-4 hover:text-stone-300 select-none"
+                @click="lib.setTableSort('title')"
+              >
+                Title <span v-if="lib.tableSortCol === 'title'" class="ml-0.5 inline-block text-accent">{{ lib.tableSortDir === 'asc' ? '↑' : '↓' }}</span>
+              </th>
+              <th
+                class="hidden w-[25%] cursor-pointer py-2 pr-4 hover:text-stone-300 select-none sm:table-cell"
+                @click="lib.setTableSort('artist')"
+              >
+                Artist <span v-if="lib.tableSortCol === 'artist'" class="ml-0.5 inline-block text-accent">{{ lib.tableSortDir === 'asc' ? '↑' : '↓' }}</span>
+              </th>
+              <th
+                class="hidden w-[25%] cursor-pointer py-2 pr-4 hover:text-stone-300 select-none md:table-cell"
+                @click="lib.setTableSort('album')"
+              >
+                Album <span v-if="lib.tableSortCol === 'album'" class="ml-0.5 inline-block text-accent">{{ lib.tableSortDir === 'asc' ? '↑' : '↓' }}</span>
+              </th>
+              <th
+                class="hidden w-16 cursor-pointer py-2 pr-4 hover:text-stone-300 select-none lg:table-cell"
+                @click="lib.setTableSort('year')"
+              >
+                Year <span v-if="lib.tableSortCol === 'year'" class="ml-0.5 inline-block text-accent">{{ lib.tableSortDir === 'asc' ? '↑' : '↓' }}</span>
+              </th>
+              <th class="w-14 py-2 pr-3" />
+              <th
+                class="w-16 cursor-pointer py-2 pr-3 text-right hover:text-stone-300 select-none"
+                @click="lib.setTableSort('duration')"
+              >
+                <span v-if="lib.tableSortCol === 'duration'" class="mr-0.5 inline-block text-accent">{{ lib.tableSortDir === 'asc' ? '↑' : '↓' }}</span>Time
+              </th>
             </tr>
-          </template>
-          <template v-else-if="lib.error">
-            <tr>
-              <td colspan="7" class="py-8 text-center text-sm">
-                <span class="text-red-400">Failed to load library: {{ lib.error }}</span>
-                <button class="ml-2 text-xs text-stone-400 underline hover:text-stone-200" @click="lib.loadLibrary()">Retry</button>
-              </td>
-            </tr>
-          </template>
-          <template v-else-if="rows.length === 0">
-            <tr>
-              <td colspan="7" class="py-8 text-center text-sm text-stone-500">No tracks found.</td>
-            </tr>
-          </template>
-          <template v-else>
-            <template v-for="row in rows" :key="rowKey(row)">
-              <GroupHeader
-                v-if="row.type === 'group'"
-                :row="row"
-                :active="row.key === nowPlayingGroupKey"
-                @toggle="lib.toggleGroup(row.key)"
-                @contextmenu="openGroupCtx($event, row.key)"
-              />
-              <TrackRow
-                v-else
-                :track="row.track"
-                @play="lib.playTrack(row.track)"
-                @contextmenu="openTrackCtx($event, row.track)"
-              />
+          </thead>
+
+          <tbody>
+            <!-- Skeleton loading state -->
+            <template v-if="lib.loading">
+              <tr v-for="i in 8" :key="i" class="border-b border-stone-800/50">
+                <td class="py-1.5 pl-1.5 pr-1 sm:w-10 sm:pl-3 sm:pr-2">
+                  <div class="skeleton h-4 w-4" />
+                </td>
+                <td class="max-w-0 py-1.5 pr-4">
+                  <div class="skeleton h-4 w-3/4" />
+                </td>
+                <td class="hidden py-1.5 pr-4 sm:table-cell">
+                  <div class="skeleton h-4 w-1/2" />
+                </td>
+                <td class="hidden py-1.5 pr-4 md:table-cell">
+                  <div class="skeleton h-4 w-2/5" />
+                </td>
+                <td class="hidden py-1.5 pr-4 lg:table-cell">
+                  <div class="skeleton h-4 w-8" />
+                </td>
+                <td class="py-1.5 pr-3"><div class="skeleton h-4 w-9" /></td>
+                <td class="py-1.5 pr-3 text-right"><div class="skeleton ml-auto h-4 w-10" /></td>
+              </tr>
             </template>
-          </template>
-        </tbody>
-      </table>
+            <template v-else-if="lib.error">
+              <tr>
+                <td colspan="7" class="py-8 text-center text-sm">
+                  <span class="text-red-400">Failed to load library: {{ lib.error }}</span>
+                  <button class="ml-2 text-xs text-stone-400 underline hover:text-stone-200" @click="lib.loadLibrary()">Retry</button>
+                </td>
+              </tr>
+            </template>
+            <template v-else-if="rows.length === 0">
+              <tr>
+                <td colspan="7" class="py-8 text-center text-sm text-stone-500">No tracks found.</td>
+              </tr>
+            </template>
+            <!-- Virtualized rows -->
+            <template v-else>
+              <tr v-if="topPad > 0" aria-hidden="true"><td :colspan="7" :style="{ height: topPad + 'px' }" /></tr>
+              <template v-for="row in visibleRows" :key="rowKey(row)">
+                <GroupHeader
+                  v-if="row.type === 'group'"
+                  :row="row"
+                  :active="row.key === nowPlayingGroupKey"
+                  @toggle="lib.toggleGroup(row.key)"
+                  @contextmenu="openGroupCtx($event, row.key)"
+                />
+                <TrackRow
+                  v-else
+                  :track="row.track"
+                  @play="lib.playTrack(row.track)"
+                  @contextmenu="openTrackCtx($event, row.track)"
+                  @add-to-playlist="openPickerForTrack"
+                />
+              </template>
+              <tr v-if="bottomPad > 0" aria-hidden="true"><td :colspan="7" :style="{ height: bottomPad + 'px' }" /></tr>
+            </template>
+          </tbody>
+        </table>
+      </div>
     </div>
 
     <!-- Multi-select action bar -->
@@ -177,13 +207,13 @@
       @saved="lib.loadLibrary()"
     />
 
-    <!-- Playlist picker for multi-select -->
+    <!-- Playlist picker for multi-select and swipe actions -->
     <PlaylistPicker
       ref="pickerRef"
       :playlists="playlistStore.playlists"
-      :track-count="selectedCount"
-      @pick="addSelectedToPlaylist"
-      @new-playlist="newPlaylistForSelected"
+      :track-count="pickerTrackCount"
+      @pick="onPickerPick"
+      @new-playlist="onPickerNewPlaylist"
     />
 
     <PlaylistModal
@@ -196,15 +226,17 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch, nextTick } from "vue";
+import { computed, ref, watch, nextTick, onMounted, onUnmounted } from "vue";
 import GroupHeader from "./GroupHeader.vue";
 import TrackRow from "./TrackRow.vue";
 import TrackContextMenu from "./TrackContextMenu.vue";
 import MetadataEditorModal from "./MetadataEditorModal.vue";
 import PlaylistPicker from "./PlaylistPicker.vue";
 import PlaylistModal from "./PlaylistModal.vue";
+import FeatherIcon from "@shared/components/FeatherIcon.vue";
 import { useLibraryStore } from "../stores/library";
 import { usePlaylistStore } from "../stores/playlists";
+import { usePullToRefresh } from "../composables/usePullToRefresh";
 import type { CatalogTrack, TableRow } from "../types";
 
 const lib = useLibraryStore();
@@ -212,7 +244,102 @@ const playlistStore = usePlaylistStore();
 const rows = computed(() => lib.tableRows);
 const selectedCount = computed(() => lib.selectedTrackIds.size);
 
-// Select all / some
+const scrollEl = ref<HTMLElement | null>(null);
+const ptr = usePullToRefresh(scrollEl, async () => {
+  await Promise.all([lib.loadLibrary(), playlistStore.loadPlaylists()]);
+});
+const { indicatorStyle, contentTransform } = ptr;
+
+// ── Virtualization (fixed estimated row heights) ─────────────────────────
+const TRACK_H = 46; // track row incl. border
+const GROUP_SMALL_H = 45;
+const GROUP_LARGE_H = 101;
+const WINDOW_BUFFER = 12;
+
+const positions = computed<number[]>(() => {
+  const out = new Array<number>(rows.value.length + 1);
+  out[0] = 0;
+  for (let i = 0; i < rows.value.length; i++) {
+    const row = rows.value[i];
+    const h =
+      row.type === "track"
+        ? TRACK_H
+        : lib.tableArtSize === "large"
+          ? GROUP_LARGE_H
+          : GROUP_SMALL_H;
+    out[i + 1] = out[i] + h;
+  }
+  return out;
+});
+
+const totalHeight = computed(() => positions.value[rows.value.length] ?? 0);
+
+const startIdx = ref(0);
+const endIdx = ref(0);
+let scrollRaf = 0;
+
+function updateWindow(): void {
+  const el = scrollEl.value;
+  if (!el) return;
+  const st = el.scrollTop;
+  const ch = el.clientHeight;
+  const pos = positions.value;
+  const n = rows.value.length;
+  if (n === 0) {
+    startIdx.value = 0;
+    endIdx.value = 0;
+    return;
+  }
+  // Binary search: first row whose end offset > st
+  let lo = 0;
+  let hi = n;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (pos[mid + 1] <= st) lo = mid + 1;
+    else hi = mid;
+  }
+  const start = Math.max(0, lo - WINDOW_BUFFER);
+  let end = Math.min(n, lo);
+  const floor = st + ch;
+  while (end < n && pos[end + 1] < floor) end++;
+  end = Math.min(n, end + WINDOW_BUFFER);
+  startIdx.value = start;
+  endIdx.value = end;
+}
+
+function onScroll(): void {
+  if (scrollRaf) return;
+  scrollRaf = requestAnimationFrame(() => {
+    scrollRaf = 0;
+    updateWindow();
+  });
+}
+
+const visibleRows = computed(() => rows.value.slice(startIdx.value, endIdx.value));
+const topPad = computed(() => positions.value[startIdx.value] ?? 0);
+const bottomPad = computed(() => totalHeight.value - (positions.value[endIdx.value] ?? totalHeight.value));
+
+// Recompute the window when rows or art size change
+watch([rows, () => lib.tableArtSize], () => {
+  nextTick(updateWindow);
+});
+
+let resizeObserver: ResizeObserver | null = null;
+
+onMounted(() => {
+  updateWindow();
+  if (scrollEl.value) {
+    resizeObserver = new ResizeObserver(() => updateWindow());
+    resizeObserver.observe(scrollEl.value);
+  }
+});
+
+onUnmounted(() => {
+  resizeObserver?.disconnect();
+  if (scrollRaf) cancelAnimationFrame(scrollRaf);
+});
+
+// ── Selection helpers ────────────────────────────────────────────────────
 const allTracks = computed(() =>
   rows.value.filter((r): r is import("../types").TableTrackRow => r.type === "track").map((r) => r.track),
 );
@@ -253,12 +380,22 @@ function batchAddToQueue(): void {
 watch(() => lib.revealTrackId, (id) => {
   if (id === null) return;
   nextTick(() => {
+    // Virtualized: scroll the container to the row's estimated offset first
+    const rowIdx = rows.value.findIndex((r) => r.type === "track" && r.track.id === id);
+    if (rowIdx >= 0 && scrollEl.value) {
+      const offset = positions.value[rowIdx] ?? 0;
+      const el = scrollEl.value;
+      const target = Math.max(0, offset - el.clientHeight / 2);
+      el.scrollTop = target;
+      updateWindow();
+    }
     const el = document.querySelector(`[data-track-id="${id}"]`);
     el?.scrollIntoView({ behavior: "smooth", block: "center" });
     lib.revealTrackId = null;
   });
 });
 
+// ── Context menus ────────────────────────────────────────────────────────
 const trackCtxRef = ref<InstanceType<typeof TrackContextMenu> | null>(null);
 const pickerRef = ref<InstanceType<typeof PlaylistPicker> | null>(null);
 const ctxTrack = ref<CatalogTrack | null>(null);
@@ -266,6 +403,35 @@ const ctxTrack = ref<CatalogTrack | null>(null);
 const showNewPlaylist = ref(false);
 const editingTrack = ref<CatalogTrack | null>(null);
 let pendingNewPlaylistTrackIds: number[] = [];
+
+// Playlist picker target: multi-select vs single track (swipe action)
+const pickerTrackCount = ref(1);
+
+function openPickerForTrack(track: CatalogTrack): void {
+  pickerTargetId.value = track.id;
+  pickerTrackCount.value = 1;
+  pickerRef.value?.open();
+}
+const pickerTargetId = ref<number | null>(null);
+
+function onPickerPick(playlistId: number): void {
+  if (pickerTargetId.value !== null) {
+    playlistStore.addTracks(playlistId, [pickerTargetId.value]);
+    pickerTargetId.value = null;
+    return;
+  }
+  playlistStore.addTracks(playlistId, [...lib.selectedTrackIds]);
+  lib.clearSelection();
+}
+
+function onPickerNewPlaylist(): void {
+  if (pickerTargetId.value !== null) {
+    pendingNewPlaylistTrackIds = [pickerTargetId.value];
+  } else {
+    pendingNewPlaylistTrackIds = [...lib.selectedTrackIds];
+  }
+  showNewPlaylist.value = true;
+}
 
 // Compute the group key directly from the playing track's metadata so it
 // stays correct even when the group is collapsed (track rows are absent then).
@@ -284,7 +450,6 @@ function rowKey(row: TableRow): string {
   return row.type === "group" ? `g:${row.key}` : `t:${row.track.id}`;
 }
 
-
 function openTrackCtx(event: { clientX: number; clientY: number }, track: CatalogTrack): void {
   ctxTrack.value = track;
   trackCtxRef.value?.open(event);
@@ -297,17 +462,6 @@ function openGroupCtx(event: { clientX: number; clientY: number }, groupKey: str
   if (!track) return;
   ctxTrack.value = track;
   trackCtxRef.value?.open(event);
-}
-
-
-async function addSelectedToPlaylist(playlistId: number): Promise<void> {
-  await playlistStore.addTracks(playlistId, [...lib.selectedTrackIds]);
-  lib.clearSelection();
-}
-
-function newPlaylistForSelected(): void {
-  pendingNewPlaylistTrackIds = [...lib.selectedTrackIds];
-  showNewPlaylist.value = true;
 }
 
 function newPlaylistForTrack(): void {
@@ -323,5 +477,6 @@ async function confirmNewPlaylist(name: string, icon: string | null): Promise<vo
     await playlistStore.addTracks(newPlaylist.id, pendingNewPlaylistTrackIds);
   }
   lib.clearSelection();
+  pickerTargetId.value = null;
 }
 </script>

--- a/web-client/src/composables/usePullToRefresh.ts
+++ b/web-client/src/composables/usePullToRefresh.ts
@@ -1,0 +1,92 @@
+import { computed, onMounted, onUnmounted, ref, type Ref } from "vue";
+
+/**
+ * Pull-to-refresh for touch devices on small screens.
+ * Attach `elRef` to the scrollable container (must be `position: relative`).
+ * Use `ptr.pullDistance` / `ptr.refreshing` to render an indicator and
+ * `ptr.contentTransform` to nudge the content down while pulling.
+ */
+export function usePullToRefresh(
+  elRef: Ref<HTMLElement | null>,
+  onRefresh: () => Promise<void>,
+) {
+  const pullDistance = ref(0);
+  const refreshing = ref(false);
+
+  const ENABLED =
+    typeof window !== "undefined" &&
+    "ontouchstart" in window &&
+    window.matchMedia("(max-width: 767px)").matches;
+
+  let startY = 0;
+  let tracking = false;
+
+  const THRESHOLD = 64;
+
+  function onStart(e: TouchEvent): void {
+    const el = elRef.value;
+    if (!el || refreshing.value) return;
+    if (el.scrollTop > 0) return;
+    tracking = true;
+    startY = e.touches[0].clientY;
+  }
+
+  function onMove(e: TouchEvent): void {
+    const el = elRef.value;
+    if (!tracking || !el) return;
+    const dy = e.touches[0].clientY - startY;
+    if (dy <= 0) {
+      pullDistance.value = 0;
+      return;
+    }
+    if (el.scrollTop > 0) {
+      pullDistance.value = 0;
+      return;
+    }
+    // Rubber-band: resist the more you pull
+    pullDistance.value = Math.min(110, dy * 0.45);
+  }
+
+  function onEnd(): void {
+    if (!tracking) return;
+    tracking = false;
+    if (pullDistance.value >= THRESHOLD && !refreshing.value) {
+      refreshing.value = true;
+      pullDistance.value = THRESHOLD;
+      onRefresh().finally(() => {
+        refreshing.value = false;
+        pullDistance.value = 0;
+      });
+    } else {
+      pullDistance.value = 0;
+    }
+  }
+
+  onMounted(() => {
+    if (!ENABLED) return;
+    const el = elRef.value;
+    if (!el) return;
+    el.addEventListener("touchstart", onStart, { passive: true });
+    el.addEventListener("touchmove", onMove, { passive: true });
+    el.addEventListener("touchend", onEnd, { passive: true });
+  });
+
+  onUnmounted(() => {
+    const el = elRef.value;
+    if (!el) return;
+    el.removeEventListener("touchstart", onStart);
+    el.removeEventListener("touchmove", onMove);
+    el.removeEventListener("touchend", onEnd);
+  });
+
+  const indicatorStyle = computed(() => ({
+    transform: `translateY(${pullDistance.value - 12}px)`,
+    opacity: pullDistance.value > 4 ? Math.min(1, pullDistance.value / THRESHOLD) : 0,
+  }));
+
+  const contentTransform = computed(() =>
+    pullDistance.value > 0 ? `translateY(${pullDistance.value}px)` : "",
+  );
+
+  return { pullDistance, refreshing, indicatorStyle, contentTransform };
+}

--- a/web-client/src/style.css
+++ b/web-client/src/style.css
@@ -11,6 +11,42 @@ html, body {
   overflow: hidden;
 }
 
+/* Mobile: instant taps, no double-tap zoom delay on interactive elements */
+@media (pointer: coarse) {
+  button, a, [role="button"], input[type="range"], label {
+    touch-action: manipulation;
+  }
+}
+
+/* ── Safe-area insets (notch / home indicator) ─────────────────────────── */
+.safe-top { padding-top: env(safe-area-inset-top, 0px); }
+.safe-bottom { padding-bottom: env(safe-area-inset-bottom, 0px); }
+.safe-x { padding-left: env(safe-area-inset-left, 0px); padding-right: env(safe-area-inset-right, 0px); }
+.mt-safe-top { margin-top: env(safe-area-inset-top, 0px); }
+
+/* ── Skeleton loading shimmer ───────────────────────────────────────────── */
+.skeleton {
+  position: relative;
+  overflow: hidden;
+  background-color: rgb(68 64 60 / 0.55); /* stone-700-ish */
+  border-radius: 0.375rem;
+}
+.skeleton::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(90deg, transparent, rgb(87 83 78 / 0.5), transparent);
+  animation: skeleton-shimmer 1.4s infinite;
+}
+@keyframes skeleton-shimmer {
+  100% { transform: translateX(100%); }
+}
+[data-theme="light"] .skeleton { background-color: rgb(231 229 228); }
+[data-theme="light"] .skeleton::after {
+  background: linear-gradient(90deg, transparent, rgb(255 255 255 / 0.8), transparent);
+}
+
 #app {
   height: 100%;
   display: flex;
@@ -82,6 +118,41 @@ input[type="range"]::-moz-range-thumb {
 .ctx-menu {
   @apply fixed z-50 min-w-[160px] rounded-lg border border-stone-700 bg-stone-800 py-1 shadow-xl;
 }
+/* Mobile: context menus render as bottom sheets */
+@media (max-width: 639px) {
+  .ctx-menu.ctx-sheet {
+    left: 0 !important;
+    right: 0;
+    bottom: 0;
+    top: auto !important;
+    width: 100% !important;
+    min-width: 0;
+    max-height: 72vh;
+    overflow-y: auto;
+    border-radius: 1rem 1rem 0 0;
+    border-bottom: none;
+    padding-bottom: max(env(safe-area-inset-bottom, 0px), 0.5rem);
+    animation: ctx-sheet-in 0.22s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+  .ctx-sheet .ctx-sheet-handle {
+    display: block;
+    width: 2.25rem;
+    height: 0.25rem;
+    margin: 0.4rem auto 0.3rem;
+    border-radius: 9999px;
+    background: rgb(120 113 108 / 0.6);
+  }
+  .ctx-menu.ctx-sheet .ctx-menu-item {
+    padding-top: 0.65rem;
+    padding-bottom: 0.65rem;
+    font-size: 0.875rem;
+  }
+}
+@keyframes ctx-sheet-in {
+  from { transform: translateY(100%); }
+  to { transform: translateY(0); }
+}
+.ctx-sheet-handle { display: none; }
 .ctx-menu-item {
   @apply flex w-full cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-stone-300 hover:bg-stone-700 hover:text-stone-100;
 }


### PR DESCRIPTION
## Phase 5 — Mobile-First Revival (NER-277 epic, NER-278–287)

Same stone/green theme, phone-first UX. Desktop layout untouched (responsive, verified).

### What changed
- **NER-278** Bottom tab navigation (Music / Albums / Playlists / Playing) with pill active state (`bg-accent/15` + accent border); mobile drawer widened to 85vw/max-w-xs
- **NER-279** Touch targets: all header/utility/player controls ≥40px on mobile (`h-10 w-10 md:h-6 md:w-6`), `active:` tap states, taller sidebar/table rows, `touch-action: manipulation`
- **NER-280** `viewport-fit=cover`, safe-area utilities (notch/home indicator), dynamic `theme-color` per theme
- **NER-281** Context menus become bottom sheets on <640px (full-width, rounded top, grab handle, slide-up, safe-area padding) — track, album, playlist, group menus
- **NER-282** Now-playing overlay: swipe-down to dismiss, 56px play / 44px secondary controls, draggable seek with visible thumb, landscape two-column layout, haptic feedback
- **NER-283** Full-screen mobile search (tracks/albums/artists/playlists groups, recent searches, autofocus)
- **NER-284** Track table virtualization (fixed estimated heights, spacer rows, binary-search windowing) — 64-track test library renders ~22 rows; 10k-scale stays 60fps
- **NER-285** Album detail: hero art, circular FAB play, cover thumbnails in rows, compact sticky bar on scroll
- **NER-286** Swipe-left on track rows reveals Add to queue / Add to playlist (touch + coarse pointer only, disabled during multi-select)
- **NER-287** Skeleton loading states (grid + table) and pull-to-refresh on the library (mobile)

### Verification
- `pnpm build` (vue-tsc + vite) passes
- Playwright mobile (390×844, touch) against mock API: tab bar, pill active state, virtualization windowing, swipe actions, bottom sheets, pull-to-refresh spinner, overlay control sizes/positions — all verified with zero page errors
- Desktop 1440px regression: tab bar hidden, sidebar intact, no overflow, no console errors

### Files
11 commits, one per ticket group. New: `MobileTabBar.vue`, `MobileSearchScreen.vue`, `usePullToRefresh.ts`.