### PR TITLE
✨ feat(server): S3-compatible cloud object storage as a music source

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1223,7 +1223,7 @@ dependencies = [
 
 [[package]]
 name = "muorg-server"
-version = "2.32.3"
+version = "2.32.7"
 dependencies = [
  "axum",
  "base64 0.23.0",

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -18,6 +18,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,6 +142,15 @@ checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
@@ -176,10 +205,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -213,6 +281,16 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "crypto-common"
@@ -303,13 +381,23 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.12.1",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -439,6 +527,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -446,6 +535,23 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "futures-sink"
@@ -466,9 +572,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -507,6 +627,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -518,6 +639,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -602,6 +742,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,6 +766,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -641,6 +788,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -668,6 +816,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -817,6 +989,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,6 +1129,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "mdns-sd"
 version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1032,7 +1223,7 @@ dependencies = [
 
 [[package]]
 name = "muorg-server"
-version = "2.29.0"
+version = "2.32.3"
 dependencies = [
  "axum",
  "base64 0.23.0",
@@ -1042,6 +1233,7 @@ dependencies = [
  "mdns-sd",
  "mp3lame-encoder",
  "muorg-core",
+ "object_store",
  "reqwest",
  "rust_cast",
  "serde",
@@ -1132,6 +1324,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "object_store"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "form_urlencoded",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body-util",
+ "humantime",
+ "hyper",
+ "itertools",
+ "md-5",
+ "parking_lot",
+ "percent-encoding",
+ "quick-xml",
+ "rand 0.10.2",
+ "reqwest",
+ "ring",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "url",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
 name = "ogg_pager"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1170,6 +1399,12 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
@@ -1310,6 +1545,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1338,7 +1583,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1392,7 +1637,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1402,7 +1658,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1413,6 +1669,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redox_syscall"
@@ -1455,6 +1717,8 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
+ "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -1467,6 +1731,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -1474,12 +1739,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
 ]
@@ -1598,6 +1865,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1640,10 +1919,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "serde"
@@ -1728,7 +2039,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2183,6 +2494,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "libc",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2441,6 +2766,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2530,6 +2861,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2580,10 +2924,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/server/README.md
+++ b/server/README.md
@@ -73,6 +73,82 @@ Multiple music directories are supported — just add more volume mounts and lis
 
 ---
 
+## Cloud storage (S3-compatible)
+
+A library that outgrows the server's disk can live in an S3-compatible bucket
+instead. Cloud tracks behave exactly like local ones — search, playback with
+seeking, FLAC transcoding, cover art, Chromecast, metadata editing and backups
+all work — and local `content_paths` and buckets can coexist in one library.
+
+Reads are ranged HTTP GETs, so nothing is mirrored to disk: seeking to the
+middle of a track fetches only that slice.
+
+### 1. Create a bucket and S3 credentials
+
+Using Hetzner Object Storage as the example (cheapest per-GB EU option, and the
+setup this was verified against): Hetzner Console → Object Storage → create a
+bucket, then **Generate S3 credentials**. The secret is shown only once.
+
+### 2. Upload your library
+
+No S3 CLI needs to be installed — Docker is enough:
+
+```bash
+export AK=<access key> SK=<secret key>
+docker run --rm -v "$HOME/Music:/music:ro" -e AK -e SK --entrypoint /bin/sh minio/mc -c '
+  mc alias set hz https://nbg1.your-objectstorage.com "$AK" "$SK" --api s3v4 --path off &&
+  mc mirror --overwrite /music hz/muorg'
+```
+
+`--path off` selects virtual-hosted addressing, which is what Hetzner expects.
+
+### 3. Point the server at it
+
+In `muorg-server.toml`:
+
+```toml
+[[library.remotes]]
+name = "cloud"                  # letters/digits/-/_ only
+bucket = "muorg"
+endpoint = "https://nbg1.your-objectstorage.com"
+region = "nbg1"
+virtual_hosted_style = true     # required for Hetzner
+# prefix = "albums"             # optional sub-folder inside the bucket
+```
+
+Credentials come from the environment so they stay out of the config file:
+`MUORG_REMOTE_CLOUD_ACCESS_KEY_ID` and `MUORG_REMOTE_CLOUD_SECRET_ACCESS_KEY`
+(the `CLOUD` part is the remote's `name`, uppercased). They can also be set as
+`access_key_id` / `secret_access_key` in the TOML, but the environment wins.
+
+### Provider settings
+
+Only three values differ between providers:
+
+| Provider | `endpoint` | `region` | `virtual_hosted_style` |
+|---|---|---|---|
+| Hetzner Object Storage | `https://<loc>.your-objectstorage.com` (`loc` = `nbg1`/`fsn1`/`hel1`) | same location code | `true` |
+| Cloudflare R2 | `https://<account-id>.r2.cloudflarestorage.com` | `auto` | `false` |
+| Backblaze B2 | `https://s3.<region>.backblazeb2.com` | e.g. `us-west-004` | `false` |
+| Wasabi | `https://s3.<region>.wasabisys.com` | e.g. `eu-central-1` | `false` |
+| MinIO (self-hosted) | `http://host:9000` | `us-east-1` | `false` |
+
+### Notes
+
+- The first scan of a large library (~60 k tracks) takes roughly 20 minutes at
+  the default concurrency and runs in the **background** — the API and clients
+  are usable while it runs, with the track list filling in as it goes.
+- Later scans issue one bucket listing and no per-object reads: only objects
+  whose `last_modified` changed are re-read.
+- Cover art for cloud tracks is cached on disk (`storage.cover_cache_dir`,
+  512 MiB by default) so browsing a library does not hit the bucket per row.
+- Editing tags on a cloud track downloads the object, rewrites it and uploads it
+  again. It is a user-initiated action, so the extra round trip is deliberate.
+- If an upload fails with a payload or checksum error, set
+  `unsigned_payload = true` on that remote.
+
+---
+
 ## Configuration reference (`muorg-server.toml`)
 
 ```toml
@@ -84,10 +160,21 @@ api_key = "secret"         # Bearer token required on all /api/* requests
 [library]
 content_paths = ["/music"] # music directories to index (inside the container)
 scan_on_startup = true     # re-scan on every container start
+remote_scan_concurrency = 8       # parallel tag reads during a cloud scan
+
+# Optional, repeatable — see "Cloud storage (S3-compatible)" above.
+# [[library.remotes]]
+# name = "cloud"
+# bucket = "muorg"
+# endpoint = "https://nbg1.your-objectstorage.com"
+# region = "nbg1"
+# virtual_hosted_style = true
 
 [storage]
 db_path = "/data/muorg.db"        # SQLite database location
 backup_dir = "/data/backups"      # metadata backup directory
+cover_cache_dir = "/data/covers"  # cover cache for cloud tracks (default: <db dir>/covers)
+cover_cache_max_bytes = 536870912 # 512 MiB
 
 [cors]
 allowed_origins = ["*"]    # restrict to your domain for public deployments

--- a/server/README.md
+++ b/server/README.md
@@ -116,6 +116,10 @@ virtual_hosted_style = true     # required for Hetzner
 # prefix = "albums"             # optional sub-folder inside the bucket
 ```
 
+Put this block **at the end of the `[library]` section**. TOML binds every bare
+key after a table header to that table, so a plain `[library]` setting placed
+below it (like `remote_scan_concurrency`) would be read as part of the remote.
+
 Credentials come from the environment so they stay out of the config file:
 `MUORG_REMOTE_CLOUD_ACCESS_KEY_ID` and `MUORG_REMOTE_CLOUD_SECRET_ACCESS_KEY`
 (the `CLOUD` part is the remote's `name`, uppercased). They can also be set as

--- a/server/crates/muorg-core/src/catalog/db.rs
+++ b/server/crates/muorg-core/src/catalog/db.rs
@@ -244,18 +244,30 @@ pub fn init_schema(conn: &rusqlite::Connection) -> Result<(), String> {
     Ok(())
 }
 
+/// Number of trailing bytes of a track that feed the content hash.
+pub const CONTENT_HASH_TAIL_BYTES: u64 = 65_536;
+
+/// Content hash from its two inputs: the total size and the last
+/// [`CONTENT_HASH_TAIL_BYTES`] bytes (fewer for a shorter file).
+///
+/// Split out of [`compute_content_hash`] so sources without a local file —
+/// object storage — produce byte-identical hashes, which is what makes
+/// hash-based move detection work across backends.
+pub fn content_hash_from_parts(file_size: u64, tail: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(file_size.to_le_bytes());
+    hasher.update(tail);
+    hasher.finalize().iter().map(|b| format!("{:02x}", b)).collect()
+}
+
 pub fn compute_content_hash(path: &Path) -> Result<String, String> {
     let mut file = std::fs::File::open(path).map_err(|e| e.to_string())?;
     let file_size = file.metadata().map_err(|e| e.to_string())?.len();
-    let mut hasher = Sha256::new();
-    hasher.update(file_size.to_le_bytes());
-    const TAIL_SIZE: u64 = 65_536;
-    let offset = file_size.saturating_sub(TAIL_SIZE);
+    let offset = file_size.saturating_sub(CONTENT_HASH_TAIL_BYTES);
     file.seek(SeekFrom::Start(offset)).map_err(|e| e.to_string())?;
-    let mut buf = Vec::with_capacity(TAIL_SIZE as usize);
+    let mut buf = Vec::with_capacity(CONTENT_HASH_TAIL_BYTES as usize);
     file.read_to_end(&mut buf).map_err(|e| e.to_string())?;
-    hasher.update(&buf);
-    Ok(hasher.finalize().iter().map(|b| format!("{:02x}", b)).collect())
+    Ok(content_hash_from_parts(file_size, &buf))
 }
 
 pub fn update_track_hash(
@@ -366,6 +378,54 @@ pub fn get_track_path_by_id(conn: &rusqlite::Connection, id: i64) -> Result<Opti
         Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
         Err(e) => Err(e.to_string()),
     }
+}
+
+/// `(path, mtime_secs)` for a live track. Lets callers that need both avoid a
+/// second query — the cover cache keys on `mtime_secs`.
+pub fn get_track_path_and_mtime_by_id(
+    conn: &rusqlite::Connection,
+    id: i64,
+) -> Result<Option<(String, i64)>, String> {
+    let result = conn.query_row(
+        "SELECT path, mtime_secs FROM tracks WHERE id = ?1 AND deleted_at IS NULL",
+        [id],
+        |r| Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)?)),
+    );
+    match result {
+        Ok(row) => Ok(Some(row)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+/// `mtime_secs` of a live track by path; `None` when absent or soft-deleted.
+pub fn get_track_mtime_by_path(
+    conn: &rusqlite::Connection,
+    path: &str,
+) -> Result<Option<i64>, String> {
+    let result = conn.query_row(
+        "SELECT mtime_secs FROM tracks WHERE path = ?1 AND deleted_at IS NULL",
+        [path],
+        |r| r.get::<_, i64>(0),
+    );
+    match result {
+        Ok(mtime) => Ok(Some(mtime)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+pub fn update_track_mtime(
+    conn: &rusqlite::Connection,
+    path: &str,
+    mtime_secs: i64,
+) -> Result<(), String> {
+    conn.execute(
+        "UPDATE tracks SET mtime_secs = ?1 WHERE path = ?2",
+        rusqlite::params![mtime_secs, path],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(())
 }
 
 fn load_tracks_filtered(
@@ -490,25 +550,201 @@ fn format_from_path(path: &Path) -> Option<&'static str> {
         })
 }
 
-pub fn scan_and_insert(conn: &rusqlite::Connection, root_path: &str) -> Result<u64, String> {
-    let root_id: i64 = conn
-        .query_row("SELECT id FROM roots WHERE path = ?1", [root_path], |r| {
-            r.get(0)
+/// One track as observed by a scanner, ready to be upserted.
+pub struct ScannedTrack<'a> {
+    /// Local absolute path or `remote://` URI, stored verbatim.
+    pub path: &'a str,
+    /// `"mp3"` or `"flac"`.
+    pub format: &'a str,
+    pub mtime_secs: i64,
+    pub content_hash: Option<&'a str>,
+    /// Carried explicitly rather than derived from `meta` so scanners can drop
+    /// large embedded pictures before batching rows.
+    pub has_cover: bool,
+    pub meta: &'a metadata::TrackMetadata,
+}
+
+/// Per-root upsert context: resolves the root id and schema capability flags
+/// once, then applies the move/rename detection to each scanned track.
+pub struct RootUpsert<'c> {
+    conn: &'c rusqlite::Connection,
+    root_id: i64,
+    featuring_col: bool,
+    use_smart_upsert: bool,
+}
+
+impl<'c> RootUpsert<'c> {
+    pub fn new(conn: &'c rusqlite::Connection, root_path: &str) -> Result<Self, String> {
+        let root_id: i64 = conn
+            .query_row("SELECT id FROM roots WHERE path = ?1", [root_path], |r| {
+                r.get(0)
+            })
+            .map_err(|e| e.to_string())?;
+        let featuring_col = schema_has_column(conn, "tracks", "featuring")?;
+        let deleted_at_col = schema_has_column(conn, "tracks", "deleted_at")?;
+        let content_hash_col = schema_has_column(conn, "tracks", "content_hash")?;
+        Ok(Self {
+            conn,
+            root_id,
+            featuring_col,
+            use_smart_upsert: deleted_at_col && content_hash_col,
         })
+    }
+
+    /// Inserts or updates one track. On a schema with soft deletes and content
+    /// hashes this reuses an existing row when the track merely moved, so
+    /// playlists, ratings and play counts survive a rename: exact
+    /// `root_id + path`, then the same path in any root, then an identical
+    /// content hash, then a matching path suffix.
+    pub fn upsert(&self, t: &ScannedTrack<'_>) -> Result<(), String> {
+        let conn = self.conn;
+        let root_id = self.root_id;
+        let featuring_col = self.featuring_col;
+        let ScannedTrack { path: path_str, format, mtime_secs, content_hash: hash, has_cover, meta } = *t;
+
+        if self.use_smart_upsert {
+            let by_path: Option<i64> = conn
+                .query_row(
+                    "SELECT id FROM tracks WHERE root_id = ?1 AND path = ?2",
+                    rusqlite::params![root_id, path_str],
+                    |r| r.get(0),
+                )
+                .ok();
+
+            if let Some(track_id) = by_path {
+                return update_track_row(conn, track_id, root_id, path_str, meta, format, mtime_secs, has_cover, hash, featuring_col);
+            }
+
+            let by_path_any_root: Option<i64> = conn
+                .query_row(
+                    "SELECT id FROM tracks WHERE path = ?1 AND deleted_at IS NOT NULL LIMIT 1",
+                    [path_str],
+                    |r| r.get(0),
+                )
+                .ok();
+
+            if let Some(track_id) = by_path_any_root {
+                return update_track_row(conn, track_id, root_id, path_str, meta, format, mtime_secs, has_cover, hash, featuring_col);
+            }
+
+            if let Some(h) = hash {
+                let by_hash: Option<i64> = conn
+                    .query_row(
+                        "SELECT id FROM tracks WHERE content_hash = ?1 AND deleted_at IS NOT NULL LIMIT 1",
+                        [h],
+                        |r| r.get(0),
+                    )
+                    .ok();
+
+                if let Some(track_id) = by_hash {
+                    return update_track_row(conn, track_id, root_id, path_str, meta, format, mtime_secs, has_cover, hash, featuring_col);
+                }
+            }
+
+            let by_suffix: Option<i64> = conn
+                .query_row(
+                    "SELECT t.id FROM tracks t \
+                     JOIN roots r ON r.id = t.root_id \
+                     WHERE t.deleted_at IS NOT NULL \
+                     AND t.content_hash IS NULL \
+                     AND ?1 LIKE '%' || SUBSTR(t.path, LENGTH(r.path) + 2) \
+                     ORDER BY LENGTH(t.path) DESC \
+                     LIMIT 1",
+                    [path_str],
+                    |r| r.get(0),
+                )
+                .ok();
+
+            if let Some(track_id) = by_suffix {
+                return update_track_row(conn, track_id, root_id, path_str, meta, format, mtime_secs, has_cover, hash, featuring_col);
+            }
+
+            return insert_track_row(conn, root_id, path_str, meta, format, mtime_secs, has_cover, hash, featuring_col);
+        }
+
+        let insert_sql = if featuring_col {
+            "INSERT OR REPLACE INTO tracks (root_id, path, title, artist, album, album_artist, featuring, year, genre, track_number, disc_number, duration_secs, format, mtime_secs, has_cover) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)"
+        } else {
+            "INSERT OR REPLACE INTO tracks (root_id, path, title, artist, album, album_artist, year, genre, track_number, disc_number, duration_secs, format, mtime_secs, has_cover) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)"
+        };
+        let mut legacy_insert = conn.prepare_cached(insert_sql).map_err(|e| e.to_string())?;
+        if featuring_col {
+            legacy_insert
+                .execute(rusqlite::params![
+                    root_id, path_str, meta.title, meta.artist, meta.album, meta.album_artist,
+                    meta.featuring, meta.year.map(|y| y as i64), meta.genre,
+                    meta.track_number.map(|n| n as i64), meta.disc_number.map(|n| n as i64),
+                    meta.duration_secs.map(|d| d as i64), format, mtime_secs,
+                    if has_cover { 1i64 } else { 0i64 },
+                ])
+                .map_err(|e| e.to_string())?;
+        } else {
+            legacy_insert
+                .execute(rusqlite::params![
+                    root_id, path_str, meta.title, meta.artist, meta.album, meta.album_artist,
+                    meta.year.map(|y| y as i64), meta.genre,
+                    meta.track_number.map(|n| n as i64), meta.disc_number.map(|n| n as i64),
+                    meta.duration_secs.map(|d| d as i64), format, mtime_secs,
+                    if has_cover { 1i64 } else { 0i64 },
+                ])
+                .map_err(|e| e.to_string())?;
+        }
+        Ok(())
+    }
+}
+
+/// Soft-deletes (hard-deletes on a legacy schema) live tracks of `root_path`
+/// whose path is not in `present`, and returns how many were removed.
+///
+/// The counterpart to [`rescan_root`]'s `Path::exists()` sweep for backends
+/// where presence comes from a listing rather than the filesystem.
+pub fn sweep_missing_tracks(
+    conn: &rusqlite::Connection,
+    root_path: &str,
+    present: &std::collections::HashSet<String>,
+) -> Result<u64, String> {
+    let root_id: i64 = conn
+        .query_row("SELECT id FROM roots WHERE path = ?1", [root_path], |r| r.get(0))
+        .map_err(|e| e.to_string())?;
+    let deleted_at_col = schema_has_column(conn, "tracks", "deleted_at")?;
+    let mut stmt = conn
+        .prepare("SELECT id, path FROM tracks WHERE root_id = ?1 AND deleted_at IS NULL")
+        .map_err(|e| e.to_string())?;
+    let rows: Vec<(i64, String)> = stmt
+        .query_map([root_id], |r| Ok((r.get(0)?, r.get(1)?)))
+        .map_err(|e| e.to_string())?
+        .collect::<Result<Vec<_>, _>>()
         .map_err(|e| e.to_string())?;
 
-    let mut count = 0u64;
-    let featuring_col = schema_has_column(conn, "tracks", "featuring")?;
-    let deleted_at_col = schema_has_column(conn, "tracks", "deleted_at")?;
-    let content_hash_col = schema_has_column(conn, "tracks", "content_hash")?;
-    let use_smart_upsert = deleted_at_col && content_hash_col;
-
-    let insert_sql = if featuring_col {
-        "INSERT OR REPLACE INTO tracks (root_id, path, title, artist, album, album_artist, featuring, year, genre, track_number, disc_number, duration_secs, format, mtime_secs, has_cover) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)"
+    let mut removed = 0u64;
+    if deleted_at_col {
+        let now = now_secs()?;
+        let mut soft_del = conn
+            .prepare("UPDATE tracks SET deleted_at = ?1 WHERE id = ?2")
+            .map_err(|e| e.to_string())?;
+        for (id, path) in rows {
+            if !present.contains(&path) {
+                soft_del.execute(rusqlite::params![now, id]).map_err(|e| e.to_string())?;
+                removed += 1;
+            }
+        }
     } else {
-        "INSERT OR REPLACE INTO tracks (root_id, path, title, artist, album, album_artist, year, genre, track_number, disc_number, duration_secs, format, mtime_secs, has_cover) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)"
-    };
-    let mut legacy_insert = conn.prepare(insert_sql).map_err(|e| e.to_string())?;
+        let mut del = conn
+            .prepare("DELETE FROM tracks WHERE id = ?1")
+            .map_err(|e| e.to_string())?;
+        for (id, path) in rows {
+            if !present.contains(&path) {
+                del.execute([id]).map_err(|e| e.to_string())?;
+                removed += 1;
+            }
+        }
+    }
+    Ok(removed)
+}
+
+pub fn scan_and_insert(conn: &rusqlite::Connection, root_path: &str) -> Result<u64, String> {
+    let up = RootUpsert::new(conn, root_path)?;
+    let mut count = 0u64;
 
     for entry in WalkDir::new(root_path)
         .follow_links(false)
@@ -536,103 +772,20 @@ pub fn scan_and_insert(conn: &rusqlite::Connection, root_path: &str) -> Result<u
             Err(_) => continue,
         };
 
-        let has_cover = meta.picture_base64.as_ref().is_some_and(|s| !s.is_empty());
-
-        if use_smart_upsert {
-            let hash = compute_content_hash(path).ok();
-
-            let by_path: Option<i64> = conn
-                .query_row(
-                    "SELECT id FROM tracks WHERE root_id = ?1 AND path = ?2",
-                    rusqlite::params![root_id, &path_str],
-                    |r| r.get(0),
-                )
-                .ok();
-
-            if let Some(track_id) = by_path {
-                update_track_row(conn, track_id, root_id, &path_str, &meta, format, mtime_secs, has_cover, hash.as_deref(), featuring_col)?;
-                count += 1;
-                continue;
-            }
-
-            let by_path_any_root: Option<i64> = conn
-                .query_row(
-                    "SELECT id FROM tracks WHERE path = ?1 AND deleted_at IS NOT NULL LIMIT 1",
-                    [&path_str],
-                    |r| r.get(0),
-                )
-                .ok();
-
-            if let Some(track_id) = by_path_any_root {
-                update_track_row(conn, track_id, root_id, &path_str, &meta, format, mtime_secs, has_cover, hash.as_deref(), featuring_col)?;
-                count += 1;
-                continue;
-            }
-
-            if let Some(ref h) = hash {
-                let by_hash: Option<i64> = conn
-                    .query_row(
-                        "SELECT id FROM tracks WHERE content_hash = ?1 AND deleted_at IS NOT NULL LIMIT 1",
-                        [h],
-                        |r| r.get(0),
-                    )
-                    .ok();
-
-                if let Some(track_id) = by_hash {
-                    update_track_row(conn, track_id, root_id, &path_str, &meta, format, mtime_secs, has_cover, hash.as_deref(), featuring_col)?;
-                    count += 1;
-                    continue;
-                }
-            }
-
-            {
-                let by_suffix: Option<i64> = conn
-                    .query_row(
-                        "SELECT t.id FROM tracks t \
-                         JOIN roots r ON r.id = t.root_id \
-                         WHERE t.deleted_at IS NOT NULL \
-                         AND t.content_hash IS NULL \
-                         AND ?1 LIKE '%' || SUBSTR(t.path, LENGTH(r.path) + 2) \
-                         ORDER BY LENGTH(t.path) DESC \
-                         LIMIT 1",
-                        [&path_str],
-                        |r| r.get(0),
-                    )
-                    .ok();
-
-                if let Some(track_id) = by_suffix {
-                    update_track_row(conn, track_id, root_id, &path_str, &meta, format, mtime_secs, has_cover, hash.as_deref(), featuring_col)?;
-                    count += 1;
-                    continue;
-                }
-            }
-
-            insert_track_row(conn, root_id, &path_str, &meta, format, mtime_secs, has_cover, hash.as_deref(), featuring_col)?;
-            count += 1;
-            continue;
-        }
-
-        if featuring_col {
-            legacy_insert
-                .execute(rusqlite::params![
-                    root_id, path_str, meta.title, meta.artist, meta.album, meta.album_artist,
-                    meta.featuring, meta.year.map(|y| y as i64), meta.genre,
-                    meta.track_number.map(|n| n as i64), meta.disc_number.map(|n| n as i64),
-                    meta.duration_secs.map(|d| d as i64), format, mtime_secs,
-                    if has_cover { 1i64 } else { 0i64 },
-                ])
-                .map_err(|e| e.to_string())?;
+        let hash = if up.use_smart_upsert {
+            compute_content_hash(path).ok()
         } else {
-            legacy_insert
-                .execute(rusqlite::params![
-                    root_id, path_str, meta.title, meta.artist, meta.album, meta.album_artist,
-                    meta.year.map(|y| y as i64), meta.genre,
-                    meta.track_number.map(|n| n as i64), meta.disc_number.map(|n| n as i64),
-                    meta.duration_secs.map(|d| d as i64), format, mtime_secs,
-                    if has_cover { 1i64 } else { 0i64 },
-                ])
-                .map_err(|e| e.to_string())?;
-        }
+            None
+        };
+
+        up.upsert(&ScannedTrack {
+            path: &path_str,
+            format,
+            mtime_secs,
+            content_hash: hash.as_deref(),
+            has_cover: meta.picture_base64.as_ref().is_some_and(|s| !s.is_empty()),
+            meta: &meta,
+        })?;
         count += 1;
     }
     Ok(count)

--- a/server/crates/muorg-core/src/catalog/mod.rs
+++ b/server/crates/muorg-core/src/catalog/mod.rs
@@ -1,16 +1,19 @@
 mod db;
 
 pub use db::{
-    add_tracks_to_playlist, batch_update_track_metadata, compute_content_hash, count_tracks, create_playlist, create_smart_playlist,
+    add_tracks_to_playlist, batch_update_track_metadata, compute_content_hash,
+    content_hash_from_parts, count_tracks, create_playlist, create_smart_playlist,
     delete_playlist, gc_deleted_tracks, get_latest_track_backup, get_library_stats,
     get_playlist_entries, get_playlist_tracks, get_playlists_for_track, get_track_by_id,
-    get_track_path_by_id, load_most_played, load_playlists, load_recently_added, load_recently_played,
+    get_track_mtime_by_path, get_track_path_and_mtime_by_id, get_track_path_by_id,
+    load_most_played, load_playlists, load_recently_added, load_recently_played,
     load_roots, load_tracks, load_tracks_paginated, prune_play_history, record_play,
     record_track_backup, remove_playlist_entry_by_id, remove_root, remove_tracks_from_playlist,
     rename_playlist, reorder_playlist_tracks, reorder_playlists, rescan_root, resolve_smart_playlist_track_ids, save_roots,
     scan_and_insert, search_tracks, set_playlist_icon, set_smart_playlist_rules, set_track_rating,
-    update_track_hash, update_track_metadata, update_track_path, CatalogTrack, LibraryStats,
-    Playlist, PlaylistTrackEntry, TrackBackupRecord,
+    sweep_missing_tracks, update_track_hash, update_track_metadata, update_track_mtime,
+    update_track_path, CatalogTrack, LibraryStats, Playlist, PlaylistTrackEntry, RootUpsert,
+    ScannedTrack, TrackBackupRecord, CONTENT_HASH_TAIL_BYTES,
 };
 use std::path::Path;
 use std::sync::Mutex;

--- a/server/crates/muorg-core/src/metadata/mod.rs
+++ b/server/crates/muorg-core/src/metadata/mod.rs
@@ -1,3 +1,6 @@
 mod read_write;
 
-pub use read_write::{read_metadata, write_metadata, MetadataUpdate, TrackMetadata};
+pub use read_write::{
+    format_from_ext, read_metadata, read_metadata_from_reader, write_metadata, AudioFormat,
+    MetadataUpdate, TrackMetadata,
+};

--- a/server/crates/muorg-core/src/metadata/read_write.rs
+++ b/server/crates/muorg-core/src/metadata/read_write.rs
@@ -40,23 +40,59 @@ pub struct TrackMetadata {
     pub replaygain_album_peak: Option<f32>,
 }
 
-pub fn read_metadata(path: &Path) -> Result<TrackMetadata, String> {
-    let ext = path
-        .extension()
-        .and_then(|e| e.to_str())
-        .map(|s| s.to_lowercase());
-    if ext.as_deref() != Some("mp3") && ext.as_deref() != Some("flac") {
-        return Err("Unsupported format".to_string());
+/// Audio container formats muorg can read tags from.
+///
+/// Exists so callers outside this crate can pick a format without depending on
+/// `lofty`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AudioFormat {
+    Mp3,
+    Flac,
+}
+
+impl AudioFormat {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Mp3 => "mp3",
+            Self::Flac => "flac",
+        }
     }
 
-    let file_type = match ext.as_deref() {
-        Some("mp3") => FileType::Mpeg,
-        Some("flac") => FileType::Flac,
-        _ => return Err("Unsupported format".to_string()),
-    };
+    fn file_type(self) -> FileType {
+        match self {
+            Self::Mp3 => FileType::Mpeg,
+            Self::Flac => FileType::Flac,
+        }
+    }
+}
+
+/// Maps a file extension to a supported format. `ext` is matched
+/// case-insensitively and must not include the leading dot.
+pub fn format_from_ext(ext: &str) -> Option<AudioFormat> {
+    match ext.to_lowercase().as_str() {
+        "mp3" => Some(AudioFormat::Mp3),
+        "flac" => Some(AudioFormat::Flac),
+        _ => None,
+    }
+}
+
+pub fn read_metadata(path: &Path) -> Result<TrackMetadata, String> {
+    let format = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .and_then(format_from_ext)
+        .ok_or_else(|| "Unsupported format".to_string())?;
     let file = std::fs::File::open(path).map_err(|e| e.to_string())?;
-    let reader = BufReader::new(file);
-    let tagged_file = Probe::with_file_type(reader, file_type)
+    read_metadata_from_reader(BufReader::new(file), format)
+}
+
+/// Reads tags from any seekable source. Used for object-storage tracks, where
+/// there is no local file to open.
+pub fn read_metadata_from_reader<R: std::io::Read + std::io::Seek>(
+    mut reader: R,
+    format: AudioFormat,
+) -> Result<TrackMetadata, String> {
+    let tagged_file = Probe::with_file_type(&mut reader, format.file_type())
         .read()
         .map_err(|e| e.to_string())?;
 
@@ -72,21 +108,19 @@ pub fn read_metadata(path: &Path) -> Result<TrackMetadata, String> {
         meta.album_artist = tag
             .get_string(lofty::tag::ItemKey::AlbumArtist)
             .map(|s| s.to_string());
-        if ext.as_deref() == Some("flac") {
-            meta.featuring = lofty::tag::ItemKey::from_key(tag.tag_type(), "FEATURING")
-                .and_then(|k| tag.get_string(k))
-                .map(|s| s.to_string());
-        } else if ext.as_deref() == Some("mp3") {
-            meta.featuring = lofty::tag::ItemKey::from_key(tag.tag_type(), "FEATURING")
-                .and_then(|k| tag.get_string(k))
-                .map(|s| s.to_string());
-        }
+        meta.featuring = lofty::tag::ItemKey::from_key(tag.tag_type(), "FEATURING")
+            .and_then(|k| tag.get_string(k))
+            .map(|s| s.to_string());
         meta.year = tag.date().map(|d| d.year as u32);
-        if meta.year.is_none() && ext.as_deref() == Some("mp3") {
-            if let Ok(id3_tag) = id3::Tag::read_from_path(path) {
-                if let Some(y) = id3_tag.year() {
-                    if y > 0 {
-                        meta.year = Some(y as u32);
+        if meta.year.is_none() && format == AudioFormat::Mp3 {
+            // lofty does not surface a bare ID3v2 TYER/TDRC year on every file;
+            // fall back to id3's own parse before giving up.
+            if reader.seek(std::io::SeekFrom::Start(0)).is_ok() {
+                if let Ok(id3_tag) = id3::Tag::read_from2(&mut reader) {
+                    if let Some(y) = id3_tag.year() {
+                        if y > 0 {
+                            meta.year = Some(y as u32);
+                        }
                     }
                 }
             }

--- a/server/crates/muorg-server/Cargo.toml
+++ b/server/crates/muorg-server/Cargo.toml
@@ -35,7 +35,8 @@ mdns-sd = "0.20"
 rust_cast = "0.14"
 local-ip-address = "0.6"
 httpdate = "1"
+object_store = { version = "0.13", default-features = false, features = ["aws"] }
+tempfile = "3"
 
 [dev-dependencies]
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
-tempfile = "3"

--- a/server/crates/muorg-server/src/backup.rs
+++ b/server/crates/muorg-server/src/backup.rs
@@ -74,13 +74,15 @@ pub fn backup_file_name(path: &str) -> Result<String, String> {
     Ok(format!("{}-{}.{}", now, &hash[..12], ext))
 }
 
-pub fn create_backup(backup_dir: &Path, path: &str) -> Result<String, String> {
-    let src = Path::new(path);
+/// Copies `src` into `backup_dir`. `name_key` is the track's identity — its
+/// path or `remote://` URI — and determines the backup file name, so backups
+/// stay grouped per track even when the bytes come from a temp file.
+pub fn create_backup(backup_dir: &Path, src: &Path, name_key: &str) -> Result<String, String> {
     if !src.exists() {
         return Err("Track file does not exist".to_string());
     }
     std::fs::create_dir_all(backup_dir).map_err(|e| e.to_string())?;
-    let backup_path = backup_dir.join(backup_file_name(path)?);
+    let backup_path = backup_dir.join(backup_file_name(name_key)?);
     std::fs::copy(src, &backup_path).map_err(|e| format!("Backup failed: {e}"))?;
     backup_path
         .to_str()

--- a/server/crates/muorg-server/src/config.rs
+++ b/server/crates/muorg-server/src/config.rs
@@ -43,9 +43,46 @@ pub struct LibraryConfig {
     pub content_paths: Vec<String>,
     #[serde(default = "default_true")]
     pub scan_on_startup: bool,
+    /// S3-compatible buckets indexed alongside `content_paths`.
+    #[serde(default)]
+    pub remotes: Vec<RemoteConfig>,
+    /// Objects to read tags from in parallel during a remote scan.
+    #[serde(default = "default_remote_scan_concurrency")]
+    pub remote_scan_concurrency: usize,
 }
 
 fn default_true() -> bool { true }
+fn default_remote_scan_concurrency() -> usize { 8 }
+
+/// One S3-compatible bucket. Tracks from it are stored as
+/// `remote://<name>/<object-key>`.
+#[derive(Debug, Deserialize, Clone)]
+pub struct RemoteConfig {
+    /// Letters, digits, `-` and `_` only — it becomes part of the track URI.
+    pub name: String,
+    pub bucket: String,
+    /// Provider endpoint, e.g. `https://nbg1.your-objectstorage.com`. Omit for AWS S3.
+    #[serde(default)]
+    pub endpoint: Option<String>,
+    #[serde(default = "default_region")]
+    pub region: String,
+    #[serde(default)]
+    pub access_key_id: Option<String>,
+    #[serde(default)]
+    pub secret_access_key: Option<String>,
+    /// Optional sub-folder inside the bucket.
+    #[serde(default)]
+    pub prefix: Option<String>,
+    /// `true` for providers that require `<bucket>.<host>` addressing (Hetzner).
+    #[serde(default)]
+    pub virtual_hosted_style: bool,
+    /// Send `UNSIGNED-PAYLOAD` instead of signing request bodies. Some Ceph-based
+    /// gateways need this for uploads.
+    #[serde(default)]
+    pub unsigned_payload: bool,
+}
+
+fn default_region() -> String { "auto".to_string() }
 
 #[derive(Debug, Deserialize)]
 pub struct StorageConfig {
@@ -53,9 +90,16 @@ pub struct StorageConfig {
     pub backup_dir: PathBuf,
     #[serde(default = "default_backup_retention")]
     pub backup_retention_count: usize,
+    /// Where extracted cover art for remote tracks is cached. Defaults to
+    /// `covers/` next to the database.
+    #[serde(default)]
+    pub cover_cache_dir: Option<PathBuf>,
+    #[serde(default = "default_cover_cache_max_bytes")]
+    pub cover_cache_max_bytes: u64,
 }
 
 fn default_backup_retention() -> usize { 5 }
+fn default_cover_cache_max_bytes() -> u64 { 536_870_912 }
 
 impl Default for StorageConfig {
     fn default() -> Self {
@@ -63,6 +107,8 @@ impl Default for StorageConfig {
             db_path: PathBuf::from("./muorg.db"),
             backup_dir: PathBuf::from("./muorg-backups"),
             backup_retention_count: 5,
+            cover_cache_dir: None,
+            cover_cache_max_bytes: 536_870_912,
         }
     }
 }

--- a/server/crates/muorg-server/src/lib.rs
+++ b/server/crates/muorg-server/src/lib.rs
@@ -6,6 +6,7 @@ pub mod musicbrainz;
 pub mod ratelimit;
 pub mod routes;
 pub mod state;
+pub mod storage;
 pub mod transcode;
 
 use axum::{

--- a/server/crates/muorg-server/src/main.rs
+++ b/server/crates/muorg-server/src/main.rs
@@ -109,11 +109,31 @@ async fn main() {
         "muorg-server starting"
     );
 
+    // Built before the catalog opens so a typo'd endpoint or a missing key is a
+    // startup failure rather than a silently empty library.
+    let remotes = Arc::new(
+        muorg_server::storage::RemoteStores::from_config(&config.library.remotes)
+            .unwrap_or_else(|e| {
+                eprintln!("Remote storage config error: {e}");
+                std::process::exit(1);
+            }),
+    );
+
+    let cover_cache_dir = config.storage.cover_cache_dir.clone().unwrap_or_else(|| {
+        config
+            .storage
+            .db_path
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join("covers")
+    });
+
     // Ensure storage dirs exist
     if let Some(parent) = config.storage.db_path.parent() {
         std::fs::create_dir_all(parent).ok();
     }
     std::fs::create_dir_all(&config.storage.backup_dir).ok();
+    std::fs::create_dir_all(&cover_cache_dir).ok();
 
     let catalog = Catalog::new(&config.storage.db_path).unwrap_or_else(|e| {
         tracing::error!("Failed to open database: {e}");
@@ -166,9 +186,34 @@ async fn main() {
         config.server.api_key.clone(),
         server_port,
         config.transcoding,
+        remotes,
+        Arc::new(muorg_server::storage::covers::CoverCache::new(
+            cover_cache_dir,
+            config.storage.cover_cache_max_bytes,
+        )),
+        config.library.remote_scan_concurrency,
     ));
 
-    let app = build_router(state, &config.cors.allowed_origins);
+    let app = build_router(state.clone(), &config.cors.allowed_origins);
+
+    // Remote scans run in the background: a first-time index of a large bucket
+    // must not delay the listener, and the track list fills in as it goes.
+    if config.library.scan_on_startup && !state.remotes.is_empty() {
+        let st = state.clone();
+        let conc = state.remote_scan_concurrency;
+        tokio::spawn(async move {
+            for remote in st.remotes.all() {
+                let root = remote.root_uri();
+                tracing::info!(root = %root, "scanning remote library");
+                match muorg_server::storage::scan::scan_remote_root(&st, &remote, conc).await {
+                    Ok((upserted, removed)) => {
+                        tracing::info!(root = %root, upserted, removed, "remote scan complete")
+                    }
+                    Err(e) => tracing::error!(root = %root, "remote scan failed: {e}"),
+                }
+            }
+        });
+    }
 
     let listen_addr = listener.local_addr().unwrap_or(addr);
     tracing::info!(address = %listen_addr, "listening");

--- a/server/crates/muorg-server/src/routes/admin.rs
+++ b/server/crates/muorg-server/src/routes/admin.rs
@@ -23,21 +23,34 @@ pub async fn rescan(
     body: Option<Json<RescanBody>>,
 ) -> Result<Json<RescanResult>, ApiError> {
     let root_path = body.and_then(|b| b.0.root_path);
-    let conn = state.catalog.db.lock().map_err(|e| e.to_string())?;
 
-    let tracks_added = if let Some(path) = root_path {
-        // Upsert root (adds if new, resurrects if soft-deleted) then rescan.
-        muorg_core::catalog::save_roots(&conn, std::slice::from_ref(&path))?;
-        muorg_core::catalog::rescan_root(&conn, &path)?
-    } else {
-        // Rescan all active roots.
-        let roots = muorg_core::catalog::load_roots(&conn)?;
-        let mut total = 0u64;
-        for root in roots {
-            total += muorg_core::catalog::rescan_root(&conn, &root)?;
+    // Each DB section is scoped: a `MutexGuard` is `!Send` and cannot be held
+    // across the remote scanner's `.await`s.
+    let roots = match root_path {
+        Some(path) => {
+            // Upsert root (adds if new, resurrects if soft-deleted) then rescan.
+            let conn = state.catalog.db.lock().map_err(|e| e.to_string())?;
+            muorg_core::catalog::save_roots(&conn, std::slice::from_ref(&path))?;
+            vec![path]
         }
-        total
+        None => {
+            let conn = state.catalog.db.lock().map_err(|e| e.to_string())?;
+            muorg_core::catalog::load_roots(&conn)?
+        }
     };
+
+    let mut tracks_added = 0u64;
+    for root in roots {
+        if let Some(remote) = state.remotes.resolve_root(&root) {
+            tracks_added +=
+                crate::storage::scan::scan_remote_root(&state, &remote, state.remote_scan_concurrency)
+                    .await?
+                    .0;
+        } else {
+            let conn = state.catalog.db.lock().map_err(|e| e.to_string())?;
+            tracks_added += muorg_core::catalog::rescan_root(&conn, &root)?;
+        }
+    }
 
     Ok(Json(RescanResult { tracks_added }))
 }

--- a/server/crates/muorg-server/src/routes/mod.rs
+++ b/server/crates/muorg-server/src/routes/mod.rs
@@ -24,6 +24,10 @@ impl ApiError {
     pub fn not_found(msg: impl ToString) -> Self {
         ApiError(StatusCode::NOT_FOUND, msg.to_string())
     }
+
+    pub fn bad_request(msg: impl ToString) -> Self {
+        ApiError(StatusCode::BAD_REQUEST, msg.to_string())
+    }
 }
 
 impl From<String> for ApiError {

--- a/server/crates/muorg-server/src/routes/stream.rs
+++ b/server/crates/muorg-server/src/routes/stream.rs
@@ -40,20 +40,35 @@ pub struct StreamQuery {
 }
 
 struct ByteRange {
-    start: usize,
-    end: usize, // inclusive
+    start: u64,
+    end: u64, // inclusive
 }
 
-fn parse_range(range: &str, total: usize) -> Option<ByteRange> {
+fn parse_range(range: &str, total: u64) -> Option<ByteRange> {
     let s = range.strip_prefix("bytes=")?;
     let mut parts = s.splitn(2, '-');
-    let start: usize = parts.next()?.parse().ok()?;
-    let end: usize = match parts.next() {
+    let start: u64 = parts.next()?.parse().ok()?;
+    let end: u64 = match parts.next() {
         Some(e) if !e.is_empty() => e.parse().ok()?,
         _ => total.saturating_sub(1),
     };
     if start >= total || end < start { return None; }
     Some(ByteRange { start, end: end.min(total - 1) })
+}
+
+/// Distinguishes a deleted object from a broken bucket or credential, so a
+/// misconfigured remote does not masquerade as a missing track.
+fn remote_err(id: i64, e: object_store::Error) -> Response {
+    match e {
+        object_store::Error::NotFound { .. } => {
+            tracing::warn!(track_id = id, "stream: object not found in bucket");
+            StatusCode::NOT_FOUND.into_response()
+        }
+        other => {
+            tracing::error!(track_id = id, "stream: object store error: {other}");
+            StatusCode::BAD_GATEWAY.into_response()
+        }
+    }
 }
 
 // GET /stream/:id?token=<tok>  (no Bearer auth — uses short-lived token instead)
@@ -89,6 +104,11 @@ pub async fn stream_audio(
     };
 
     let is_flac = track_path.to_lowercase().ends_with(".flac");
+    let start_secs = params.start.unwrap_or(0.0).max(0.0);
+
+    if let Some((remote, key)) = state.remotes.resolve(&track_path) {
+        return stream_remote(&state, id, remote, key, is_flac, start_secs, &req_headers).await;
+    }
 
     // Shared validators: file mtime is the natural cache key
     let mtime = crate::routes::util::file_mtime(std::path::Path::new(&track_path));
@@ -104,11 +124,10 @@ pub async fn stream_audio(
         type StreamChunk = Result<Bytes, Box<dyn std::error::Error + Send + Sync>>;
         let (tx, rx) = tokio::sync::mpsc::channel::<StreamChunk>(128);
         let path = track_path.clone();
-        let start_secs = params.start.unwrap_or(0.0).max(0.0);
         tracing::info!(track_id = id, path = %track_path, start_secs, "stream flac→mp3");
         let cfg = state.transcoding_config.clone();
         tokio::task::spawn_blocking(move || {
-            transcode::transcode_to_mp3(&path, start_secs, &cfg, tx);
+            transcode::transcode_to_mp3(transcode::TranscodeSource::LocalPath(path), start_secs, &cfg, tx);
         });
         let stream = ReceiverStream::new(rx);
         let body = Body::from_stream(stream);
@@ -126,7 +145,7 @@ pub async fn stream_audio(
         tracing::info!(track_id = id, path = %track_path, range = ?range_header, "stream mp3");
         match tokio::fs::read(&track_path).await {
             Ok(data) => {
-                let total = data.len();
+                let total = data.len() as u64;
                 let range = range_header
                     .as_deref()
                     .and_then(|r| parse_range(r, total));
@@ -142,7 +161,7 @@ pub async fn stream_audio(
                 }
 
                 if let Some(r) = range {
-                    let body = data[r.start..=r.end].to_vec();
+                    let body = data[r.start as usize..=r.end as usize].to_vec();
                     headers.insert("Content-Range", format!("bytes {}-{}/{}", r.start, r.end, total).parse().unwrap());
                     headers.insert("Content-Length", body.len().to_string().parse().unwrap());
                     (StatusCode::PARTIAL_CONTENT, headers, body).into_response()
@@ -152,6 +171,97 @@ pub async fn stream_audio(
                 }
             }
             Err(_) => StatusCode::NOT_FOUND.into_response(),
+        }
+    }
+}
+
+/// Streams a track that lives in object storage.
+///
+/// A client `Range` becomes a ranged GET and the object-store byte stream is
+/// piped straight through, so seeking never pulls more than the requested slice.
+async fn stream_remote(
+    state: &Arc<AppState>,
+    id: i64,
+    remote: Arc<crate::storage::RemoteStore>,
+    key: object_store::path::Path,
+    is_flac: bool,
+    start_secs: f32,
+    req_headers: &HeaderMap,
+) -> Response {
+    use object_store::{GetOptions, GetRange, ObjectStore, ObjectStoreExt};
+
+    let head = match remote.store.head(&key).await {
+        Ok(m) => m,
+        Err(e) => return remote_err(id, e),
+    };
+
+    // Same validator shape as the local branch so client caches are unaffected.
+    let secs = head.last_modified.timestamp().max(0) as u64;
+    let mtime = Some(std::time::UNIX_EPOCH + std::time::Duration::from_secs(secs));
+    let etag = format!("\"stream-{id}-{secs}\"");
+    if let Some(resp) = crate::routes::util::check_not_modified(&etag, mtime, req_headers) {
+        return resp;
+    }
+
+    let mut headers = HeaderMap::new();
+    headers.insert("Content-Type", "audio/mpeg".parse().unwrap());
+    headers.insert("Cache-Control", "no-cache".parse().unwrap());
+    headers.insert("Vary", "Accept-Encoding".parse().unwrap());
+    headers.insert("ETag", etag.parse().unwrap());
+    if let Some(m) = mtime {
+        headers.insert("Last-Modified", crate::routes::util::http_date(m).parse().unwrap());
+    }
+
+    if is_flac {
+        type StreamChunk = Result<Bytes, Box<dyn std::error::Error + Send + Sync>>;
+        let (tx, rx) = tokio::sync::mpsc::channel::<StreamChunk>(128);
+        tracing::info!(track_id = id, key = %key, start_secs, "stream remote flac→mp3");
+        let cfg = state.transcoding_config.clone();
+        let handle = tokio::runtime::Handle::current();
+        let store = remote.store.clone();
+        let size = head.size;
+        tokio::task::spawn_blocking(move || {
+            let src = crate::storage::reader::RemoteReader::new(store, key, size, handle);
+            transcode::transcode_to_mp3(
+                transcode::TranscodeSource::Remote(Box::new(src)),
+                start_secs,
+                &cfg,
+                tx,
+            );
+        });
+        let body = Body::from_stream(ReceiverStream::new(rx));
+        return (StatusCode::OK, headers, body).into_response();
+    }
+
+    let total = head.size;
+    let range = req_headers
+        .get("range")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|r| parse_range(r, total));
+    tracing::info!(track_id = id, key = %key, total, range = ?range.as_ref().map(|r| (r.start, r.end)), "stream remote mp3");
+
+    headers.insert("Accept-Ranges", "bytes".parse().unwrap());
+    let opts = GetOptions {
+        range: range.as_ref().map(|r| GetRange::Bounded(r.start..r.end + 1)),
+        ..Default::default()
+    };
+    let res = match remote.store.get_opts(&key, opts).await {
+        Ok(r) => r,
+        Err(e) => return remote_err(id, e),
+    };
+
+    match range {
+        Some(r) => {
+            headers.insert(
+                "Content-Range",
+                format!("bytes {}-{}/{}", r.start, r.end, total).parse().unwrap(),
+            );
+            headers.insert("Content-Length", (r.end - r.start + 1).to_string().parse().unwrap());
+            (StatusCode::PARTIAL_CONTENT, headers, Body::from_stream(res.into_stream())).into_response()
+        }
+        None => {
+            headers.insert("Content-Length", total.to_string().parse().unwrap());
+            (StatusCode::OK, headers, Body::from_stream(res.into_stream())).into_response()
         }
     }
 }

--- a/server/crates/muorg-server/src/routes/tracks.rs
+++ b/server/crates/muorg-server/src/routes/tracks.rs
@@ -21,14 +21,64 @@ fn resolve_track(state: &AppState, id: i64) -> Result<String, ApiError> {
         .ok_or_else(|| ApiError::not_found(format!("Track {id} not found")))
 }
 
+fn resolve_track_with_mtime(state: &AppState, id: i64) -> Result<(String, i64), ApiError> {
+    let conn = state.catalog.db.lock().map_err(|e| e.to_string())?;
+    muorg_core::catalog::get_track_path_and_mtime_by_id(&conn, id)?
+        .ok_or_else(|| ApiError::not_found(format!("Track {id} not found")))
+}
+
+/// Reads tags from a track wherever it lives. Remote tracks are read through a
+/// ranged reader, so only the bytes the tag parser touches leave the bucket.
+pub async fn read_track_metadata(
+    state: &AppState,
+    track_path: &str,
+) -> Result<TrackMetadata, ApiError> {
+    if let Some((remote, key)) = state.remotes.resolve(track_path) {
+        let format = path::Path::new(track_path)
+            .extension()
+            .and_then(|e| e.to_str())
+            .and_then(muorg_core::metadata::format_from_ext)
+            .ok_or_else(|| ApiError::bad_request("Unsupported format"))?;
+        use object_store::ObjectStoreExt;
+        let head = remote
+            .store
+            .head(&key)
+            .await
+            .map_err(|e| format!("Object store error: {e}"))?;
+        let store = remote.store.clone();
+        let handle = tokio::runtime::Handle::current();
+        let size = head.size;
+        return tokio::task::spawn_blocking(move || {
+            let mut r = crate::storage::reader::RemoteReader::new(store, key, size, handle);
+            muorg_core::metadata::read_metadata_from_reader(&mut r, format)
+        })
+        .await
+        .map_err(|e| e.to_string())?
+        .map_err(ApiError::from);
+    }
+    let p = track_path.to_string();
+    tokio::task::spawn_blocking(move || muorg_core::metadata::read_metadata(path::Path::new(&p)))
+        .await
+        .map_err(|e| e.to_string())?
+        .map_err(ApiError::from)
+}
+
 // GET /api/tracks/:id/cover — returns binary image with correct Content-Type
 pub async fn get_cover(
     Path(id): Path<i64>,
     State(state): State<Arc<AppState>>,
     req_headers: HeaderMap,
 ) -> Result<Response, ApiError> {
-    let track_path = resolve_track(&state, id)?;
-    let mtime = crate::routes::util::file_mtime(path::Path::new(&track_path));
+    let (track_path, track_mtime_secs) = resolve_track_with_mtime(&state, id)?;
+    let is_remote = crate::storage::is_remote_uri(&track_path);
+
+    // Remote covers key off the catalog's mtime so a cache hit costs no request
+    // at all; local ones stay on the file's own mtime, as before.
+    let mtime = if is_remote {
+        Some(std::time::UNIX_EPOCH + std::time::Duration::from_secs(track_mtime_secs.max(0) as u64))
+    } else {
+        crate::routes::util::file_mtime(path::Path::new(&track_path))
+    };
     let etag = format!(
         "\"cover-{id}-{}\"",
         mtime.map(|t| t.duration_since(std::time::UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0)).unwrap_or(0)
@@ -37,15 +87,23 @@ pub async fn get_cover(
         return Ok(resp);
     }
 
-    let meta = muorg_core::metadata::read_metadata(path::Path::new(&track_path))?;
-
-    let b64 = match meta.picture_base64 {
-        Some(b) if !b.is_empty() => b,
-        _ => return Err(ApiError::not_found("No cover art")),
+    let (data, mime) = match state.cover_cache.get(id, track_mtime_secs).filter(|_| is_remote) {
+        Some(hit) => hit,
+        None => {
+            let meta = read_track_metadata(&state, &track_path).await?;
+            let b64 = match meta.picture_base64 {
+                Some(b) if !b.is_empty() => b,
+                _ => return Err(ApiError::not_found("No cover art")),
+            };
+            let mime = meta.picture_mime.unwrap_or_else(|| "image/jpeg".to_string());
+            let data = base64::Engine::decode(&base64::engine::general_purpose::STANDARD, &b64)
+                .map_err(|e| e.to_string())?;
+            if is_remote {
+                state.cover_cache.put(id, &mime, &data);
+            }
+            (data, mime)
+        }
     };
-    let mime = meta.picture_mime.unwrap_or_else(|| "image/jpeg".to_string());
-    let data = base64::Engine::decode(&base64::engine::general_purpose::STANDARD, &b64)
-        .map_err(|e| e.to_string())?;
 
     let mut headers = HeaderMap::new();
     headers.insert("Content-Type", mime.parse().unwrap());
@@ -65,7 +123,7 @@ pub async fn get_metadata(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<TrackMetadata>, ApiError> {
     let track_path = resolve_track(&state, id)?;
-    let meta = muorg_core::metadata::read_metadata(path::Path::new(&track_path))?;
+    let meta = read_track_metadata(&state, &track_path).await?;
     Ok(Json(meta))
 }
 
@@ -76,6 +134,75 @@ pub struct PatchMetadataBody {
     pub backup_before_write: Option<bool>,
 }
 
+/// What a remote write changed, and what the caller must therefore persist.
+struct RemoteWrite {
+    /// The object's new last-modified time. `tracks.mtime_secs` must follow it:
+    /// it is both the cover cache's validity key and the scanner's change key.
+    new_mtime: i64,
+    /// Hash of the bytes actually uploaded, computed locally from the temp file.
+    new_hash: Option<String>,
+}
+
+/// Writes `update` into the track's file or object.
+///
+/// Local tracks are edited in place. Remote ones are fetched to a temp file,
+/// rewritten and re-uploaded, because both taggers need a seekable read-write
+/// file. Returns `Some(_)` only for remote tracks.
+async fn write_track_metadata(
+    state: &AppState,
+    track_path: &str,
+    update: &MetadataUpdate,
+    backup: bool,
+) -> Result<Option<RemoteWrite>, ApiError> {
+    let record_backup = |state: &AppState, src: &path::Path| -> Result<(), ApiError> {
+        let backup_path_str = backup::create_backup(&state.backup_dir, src, track_path)?;
+        {
+            let conn = state.catalog.db.lock().map_err(|e| e.to_string())?;
+            muorg_core::catalog::record_track_backup(&conn, track_path, &backup_path_str)?;
+        }
+        // Prune old backups for this source file
+        let _ = backup::gc_old_backups(&state.backup_dir, state.backup_retention_count);
+        Ok(())
+    };
+
+    let Some((remote, key)) = state.remotes.resolve(track_path) else {
+        if backup {
+            record_backup(state, path::Path::new(track_path))?;
+        }
+        let (p, upd) = (track_path.to_string(), update.clone());
+        tokio::task::spawn_blocking(move || {
+            muorg_core::metadata::write_metadata(path::Path::new(&p), &upd)
+        })
+        .await
+        .map_err(|e| e.to_string())??;
+        return Ok(None);
+    };
+
+    let ext = path::Path::new(track_path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("bin");
+    let tmp = crate::storage::fetch_to_temp(&remote, &key, ext).await?;
+
+    if backup {
+        record_backup(state, tmp.path())?;
+    }
+
+    let (tmp_path, upd) = (tmp.path().to_path_buf(), update.clone());
+    tokio::task::spawn_blocking(move || muorg_core::metadata::write_metadata(&tmp_path, &upd))
+        .await
+        .map_err(|e| e.to_string())??;
+
+    let new_meta = crate::storage::put_from_file(&remote, &key, tmp.path()).await?;
+    // Identical to the hash the scanner would compute from the bucket, because
+    // both go through `content_hash_from_parts`.
+    let new_hash = muorg_core::catalog::compute_content_hash(tmp.path()).ok();
+    Ok(Some(RemoteWrite {
+        new_mtime: new_meta.last_modified.timestamp(),
+        new_hash,
+    }))
+}
+
 // PATCH /api/tracks/:id/metadata
 pub async fn patch_metadata(
     Path(id): Path<i64>,
@@ -83,23 +210,34 @@ pub async fn patch_metadata(
     Json(body): Json<PatchMetadataBody>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
     let track_path = resolve_track(&state, id)?;
-
-    if body.backup_before_write.unwrap_or(false) {
-        let backup_path_str = backup::create_backup(&state.backup_dir, &track_path)?;
-        let conn = state.catalog.db.lock().map_err(|e| e.to_string())?;
-        muorg_core::catalog::record_track_backup(&conn, &track_path, &backup_path_str)?;
-        // Prune old backups for this source file
-        let _ = backup::gc_old_backups(&state.backup_dir, state.backup_retention_count);
-    }
-
-    muorg_core::metadata::write_metadata(path::Path::new(&track_path), &body.update)?;
+    let remote_write = write_track_metadata(
+        &state,
+        &track_path,
+        &body.update,
+        body.backup_before_write.unwrap_or(false),
+    )
+    .await?;
 
     {
         let conn = state.catalog.db.lock().map_err(|e| e.to_string())?;
         muorg_core::catalog::update_track_metadata(&conn, &track_path, &body.update)?;
-        if let Ok(new_hash) = muorg_core::catalog::compute_content_hash(path::Path::new(&track_path)) {
-            let _ = muorg_core::catalog::update_track_hash(&conn, &track_path, &new_hash);
+        match &remote_write {
+            Some(w) => {
+                if let Some(h) = &w.new_hash {
+                    let _ = muorg_core::catalog::update_track_hash(&conn, &track_path, h);
+                }
+                muorg_core::catalog::update_track_mtime(&conn, &track_path, w.new_mtime)?;
+            }
+            None => {
+                if let Ok(new_hash) = muorg_core::catalog::compute_content_hash(path::Path::new(&track_path)) {
+                    let _ = muorg_core::catalog::update_track_hash(&conn, &track_path, &new_hash);
+                }
+            }
         }
+    }
+
+    if remote_write.is_some() {
+        state.cover_cache.invalidate(id);
     }
 
     Ok(Json(serde_json::json!({"ok": true})))
@@ -155,9 +293,25 @@ pub async fn restore_backup(
         muorg_core::catalog::get_latest_track_backup(&conn, &track_path)?
             .ok_or_else(|| ApiError::not_found("No backup available"))?
     };
-    std::fs::copy(&backup_record.backup_path, &track_path)
-        .map_err(|e| format!("Restore failed: {e}"))?;
-    let fresh = muorg_core::metadata::read_metadata(path::Path::new(&track_path))?;
+    // The backup itself is always a local file; only the destination differs.
+    let restored_mtime = match state.remotes.resolve(&track_path) {
+        Some((remote, key)) => Some(
+            crate::storage::put_from_file(
+                &remote,
+                &key,
+                path::Path::new(&backup_record.backup_path),
+            )
+            .await?
+            .last_modified
+            .timestamp(),
+        ),
+        None => {
+            std::fs::copy(&backup_record.backup_path, &track_path)
+                .map_err(|e| format!("Restore failed: {e}"))?;
+            None
+        }
+    };
+    let fresh = muorg_core::metadata::read_metadata(path::Path::new(&backup_record.backup_path))?;
     let update = MetadataUpdate {
         title: Some(fresh.title.map(Some).unwrap_or(None)),
         artist: Some(fresh.artist.map(Some).unwrap_or(None)),
@@ -170,10 +324,22 @@ pub async fn restore_backup(
         disc_number: Some(fresh.disc_number.map(Some).unwrap_or(None)),
         picture_base64: Some(fresh.picture_base64.map(Some).unwrap_or(None)),
     };
-    let conn = state.catalog.db.lock().map_err(|e| e.to_string())?;
-    muorg_core::catalog::update_track_metadata(&conn, &track_path, &update)?;
-    if let Ok(new_hash) = muorg_core::catalog::compute_content_hash(path::Path::new(&track_path)) {
-        let _ = muorg_core::catalog::update_track_hash(&conn, &track_path, &new_hash);
+    {
+        let conn = state.catalog.db.lock().map_err(|e| e.to_string())?;
+        muorg_core::catalog::update_track_metadata(&conn, &track_path, &update)?;
+        let hash_src = match restored_mtime {
+            Some(m) => {
+                muorg_core::catalog::update_track_mtime(&conn, &track_path, m)?;
+                path::Path::new(&backup_record.backup_path)
+            }
+            None => path::Path::new(&track_path),
+        };
+        if let Ok(new_hash) = muorg_core::catalog::compute_content_hash(hash_src) {
+            let _ = muorg_core::catalog::update_track_hash(&conn, &track_path, &new_hash);
+        }
+    }
+    if restored_mtime.is_some() {
+        state.cover_cache.invalidate(id);
     }
     Ok(Json(serde_json::json!({"ok": true})))
 }
@@ -190,6 +356,35 @@ pub async fn rename_file(
     Json(body): Json<RenameBody>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
     let old_path = resolve_track(&state, id)?;
+
+    if let Some((remote, old_key)) = state.remotes.resolve(&old_path) {
+        // A rename is a copy+delete inside one bucket; crossing backends would
+        // be a transfer, which this endpoint does not do.
+        let new_key = match state.remotes.resolve(&body.new_path) {
+            Some((new_remote, k)) if new_remote.name == remote.name => k,
+            _ => {
+                return Err(ApiError::bad_request(
+                    "Cannot move a track between storage backends",
+                ))
+            }
+        };
+        use object_store::ObjectStoreExt;
+        remote
+            .store
+            .rename(&old_key, &new_key)
+            .await
+            .map_err(|e| format!("Rename failed: {e}"))?;
+        let conn = state.catalog.db.lock().map_err(|e| e.to_string())?;
+        muorg_core::catalog::update_track_path(&conn, &old_path, &body.new_path)?;
+        return Ok(Json(serde_json::json!({"ok": true})));
+    }
+
+    if crate::storage::is_remote_uri(&body.new_path) {
+        return Err(ApiError::bad_request(
+            "Cannot move a track between storage backends",
+        ));
+    }
+
     let new = path::Path::new(&body.new_path);
     if let Some(parent) = new.parent() {
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
@@ -207,7 +402,7 @@ pub async fn auto_tag_suggestions(
     body: Option<Json<SearchQuery>>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
     let track_path = resolve_track(&state, id)?;
-    let meta = muorg_core::metadata::read_metadata(path::Path::new(&track_path))?;
+    let meta = read_track_metadata(&state, &track_path).await?;
 
     // Build query from request body or fall back to file metadata
     let query = match body {
@@ -241,22 +436,38 @@ pub async fn batch_patch_metadata(
     }
 
     // Resolve all paths first
-    let mut updates: Vec<(String, MetadataUpdate)> = Vec::with_capacity(items.len());
+    let mut updates: Vec<(i64, String, MetadataUpdate)> = Vec::with_capacity(items.len());
     for item in &items {
         let track_path = resolve_track(&state, item.id)?;
-        updates.push((track_path, item.update.clone()));
+        updates.push((item.id, track_path, item.update.clone()));
     }
 
-    // Write metadata to files
-    for (track_path, update) in &updates {
-        muorg_core::metadata::write_metadata(path::Path::new(&track_path), update)?;
+    // Write metadata to each track's file or object
+    let mut remote_writes: Vec<(usize, RemoteWrite)> = Vec::new();
+    for (i, (_, track_path, update)) in updates.iter().enumerate() {
+        if let Some(w) = write_track_metadata(&state, track_path, update, false).await? {
+            remote_writes.push((i, w));
+        }
     }
 
     // Batch update the DB in a single transaction
     {
         let conn = state.catalog.db.lock().map_err(|e| e.to_string())?;
-        let batch: Vec<(&str, &MetadataUpdate)> = updates.iter().map(|(p, u)| (p.as_str(), u)).collect();
+        let batch: Vec<(&str, &MetadataUpdate)> =
+            updates.iter().map(|(_, p, u)| (p.as_str(), u)).collect();
         muorg_core::catalog::batch_update_track_metadata(&conn, &batch)?;
+        // Remote objects changed identity: mtime drives the cover cache and the
+        // scanner, the hash drives move detection.
+        for (i, w) in &remote_writes {
+            let track_path = updates[*i].1.as_str();
+            muorg_core::catalog::update_track_mtime(&conn, track_path, w.new_mtime)?;
+            if let Some(h) = &w.new_hash {
+                let _ = muorg_core::catalog::update_track_hash(&conn, track_path, h);
+            }
+        }
+    }
+    for (i, _) in &remote_writes {
+        state.cover_cache.invalidate(updates[*i].0);
     }
 
     Ok(Json(serde_json::json!({"ok": true, "updated": updates.len()})))

--- a/server/crates/muorg-server/src/state.rs
+++ b/server/crates/muorg-server/src/state.rs
@@ -61,9 +61,15 @@ pub struct AppState {
     pub cast_session: CastState,
     pub transcoding_config: TranscodingConfig,
     pub rate_limiter: RateLimiter,
+    pub remotes: Arc<crate::storage::RemoteStores>,
+    pub cover_cache: Arc<crate::storage::covers::CoverCache>,
+    /// From `library.remote_scan_concurrency`, clamped to `>= 1`. Lets the
+    /// rescan route drive a remote scan without carrying the whole `Config`.
+    pub remote_scan_concurrency: usize,
 }
 
 impl AppState {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         catalog: Arc<Catalog>,
         backup_dir: PathBuf,
@@ -71,6 +77,9 @@ impl AppState {
         api_key: String,
         server_port: u16,
         transcoding_config: TranscodingConfig,
+        remotes: Arc<crate::storage::RemoteStores>,
+        cover_cache: Arc<crate::storage::covers::CoverCache>,
+        remote_scan_concurrency: usize,
     ) -> Self {
         let cast_discovery = DiscoveryState::new();
         cast_discovery.start();
@@ -86,6 +95,9 @@ impl AppState {
             cast_session: CastState::new(),
             transcoding_config,
             rate_limiter: RateLimiter::new(100, 60),
+            remotes,
+            cover_cache,
+            remote_scan_concurrency: remote_scan_concurrency.max(1),
         }
     }
 }

--- a/server/crates/muorg-server/src/storage/covers.rs
+++ b/server/crates/muorg-server/src/storage/covers.rs
@@ -1,0 +1,134 @@
+//! On-disk cache for cover art extracted from remote tracks.
+//!
+//! Clients request a cover per visible row, and extracting one from a bucket
+//! costs a ranged GET plus a tag parse. Cached files are keyed by track id and
+//! validated against `tracks.mtime_secs`, so any write path that changes an
+//! object must bump that column (it does) for the cache to stay correct.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Extensions the cache can hold, ordered as they are probed on lookup.
+const EXTS: [&str; 3] = ["jpg", "png", "webp"];
+
+/// Successful writes between garbage collection passes.
+const GC_EVERY: u64 = 64;
+
+pub struct CoverCache {
+    dir: PathBuf,
+    max_bytes: u64,
+    writes: AtomicU64,
+}
+
+fn ext_for_mime(mime: &str) -> &'static str {
+    match mime {
+        "image/png" => "png",
+        "image/webp" => "webp",
+        _ => "jpg",
+    }
+}
+
+fn mime_for_ext(ext: &str) -> &'static str {
+    match ext {
+        "png" => "image/png",
+        "webp" => "image/webp",
+        _ => "image/jpeg",
+    }
+}
+
+fn mtime_secs(meta: &std::fs::Metadata) -> i64 {
+    meta.modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+impl CoverCache {
+    pub fn new(dir: PathBuf, max_bytes: u64) -> Self {
+        Self {
+            dir,
+            max_bytes,
+            writes: AtomicU64::new(0),
+        }
+    }
+
+    /// The cached cover for `id`, or `None` when absent or older than the
+    /// track it belongs to. A stale entry is deleted on the way out.
+    pub fn get(&self, id: i64, track_mtime_secs: i64) -> Option<(Vec<u8>, String)> {
+        for ext in EXTS {
+            let path = self.dir.join(format!("{id}.{ext}"));
+            let Ok(meta) = std::fs::metadata(&path) else {
+                continue;
+            };
+            if mtime_secs(&meta) < track_mtime_secs {
+                let _ = std::fs::remove_file(&path);
+                continue;
+            }
+            match std::fs::read(&path) {
+                Ok(data) => return Some((data, mime_for_ext(ext).to_string())),
+                Err(_) => continue,
+            }
+        }
+        None
+    }
+
+    pub fn put(&self, id: i64, mime: &str, data: &[u8]) {
+        let ext = ext_for_mime(mime);
+        // Drop any entry under a different extension so `get` cannot serve a
+        // stale image of the other type.
+        for other in EXTS.iter().filter(|e| **e != ext) {
+            let _ = std::fs::remove_file(self.dir.join(format!("{id}.{other}")));
+        }
+        let final_path = self.dir.join(format!("{id}.{ext}"));
+        let tmp_path = self.dir.join(format!("{id}.{ext}.tmp"));
+        if std::fs::write(&tmp_path, data).is_err() {
+            let _ = std::fs::remove_file(&tmp_path);
+            return;
+        }
+        // Rename so a concurrent reader never observes a half-written file.
+        if std::fs::rename(&tmp_path, &final_path).is_err() {
+            let _ = std::fs::remove_file(&tmp_path);
+            return;
+        }
+        if self.writes.fetch_add(1, Ordering::Relaxed) % GC_EVERY == GC_EVERY - 1 {
+            self.gc();
+        }
+    }
+
+    pub fn invalidate(&self, id: i64) {
+        for ext in EXTS {
+            let _ = std::fs::remove_file(self.dir.join(format!("{id}.{ext}")));
+        }
+    }
+
+    /// Evicts oldest-first down to 90 % of `max_bytes` once the cache exceeds it.
+    fn gc(&self) {
+        let Ok(entries) = std::fs::read_dir(&self.dir) else {
+            return;
+        };
+        let mut files: Vec<(PathBuf, i64, u64)> = Vec::new();
+        let mut total = 0u64;
+        for entry in entries.flatten() {
+            let Ok(meta) = entry.metadata() else { continue };
+            if !meta.is_file() {
+                continue;
+            }
+            total += meta.len();
+            files.push((entry.path(), mtime_secs(&meta), meta.len()));
+        }
+        if total <= self.max_bytes {
+            return;
+        }
+        let target = self.max_bytes / 10 * 9;
+        files.sort_by_key(|(_, mtime, _)| *mtime);
+        for (path, _, len) in files {
+            if total <= target {
+                break;
+            }
+            if std::fs::remove_file(&path).is_ok() {
+                total = total.saturating_sub(len);
+            }
+        }
+    }
+}

--- a/server/crates/muorg-server/src/storage/mod.rs
+++ b/server/crates/muorg-server/src/storage/mod.rs
@@ -1,0 +1,201 @@
+//! S3-compatible object storage as a music source.
+//!
+//! Remote tracks live in the same `tracks.path` column as local ones, using the
+//! URI form `remote://<remote-name>/<object-key>`, so every catalog query,
+//! playlist and move-detection rule works unchanged. `<remote-name>` is
+//! restricted to `[A-Za-z0-9_-]+` at config load, which makes the URI split on
+//! the first `/` after the scheme unambiguous.
+
+pub mod covers;
+pub mod reader;
+
+use object_store::aws::AmazonS3Builder;
+use object_store::path::Path as ObjPath;
+use object_store::{ObjectMeta, ObjectStore, ObjectStoreExt};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+pub const REMOTE_SCHEME: &str = "remote://";
+
+pub fn is_remote_uri(p: &str) -> bool {
+    p.starts_with(REMOTE_SCHEME)
+}
+
+pub struct RemoteStore {
+    pub name: String,
+    pub store: Arc<dyn ObjectStore>,
+    /// Normalised: no leading or trailing `/`, empty when unset.
+    pub prefix: String,
+}
+
+impl RemoteStore {
+    /// The `roots.path` value for this remote.
+    pub fn root_uri(&self) -> String {
+        if self.prefix.is_empty() {
+            format!("{REMOTE_SCHEME}{}", self.name)
+        } else {
+            format!("{REMOTE_SCHEME}{}/{}", self.name, self.prefix)
+        }
+    }
+
+    /// Full object key -> `remote://<name>/<key>`.
+    pub fn uri_for(&self, key: &str) -> String {
+        format!("{REMOTE_SCHEME}{}/{}", self.name, key)
+    }
+}
+
+#[derive(Default)]
+pub struct RemoteStores {
+    by_name: HashMap<String, Arc<RemoteStore>>,
+}
+
+impl RemoteStores {
+    pub fn from_config(cfgs: &[crate::config::RemoteConfig]) -> Result<Self, String> {
+        let mut by_name: HashMap<String, Arc<RemoteStore>> = HashMap::new();
+        for c in cfgs {
+            let name = c.name.as_str();
+            let valid = !name.is_empty()
+                && name
+                    .chars()
+                    .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_');
+            if !valid || by_name.contains_key(name) {
+                return Err(format!("remote '{name}': invalid or duplicate name"));
+            }
+
+            let env_key: String = name
+                .to_uppercase()
+                .chars()
+                .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '_' })
+                .collect();
+            let cred = |field: &str, from_toml: &Option<String>| -> Result<String, String> {
+                let env_var = format!("MUORG_REMOTE_{env_key}_{}", field.to_uppercase());
+                // Environment wins so secrets can stay out of the config file.
+                std::env::var(&env_var)
+                    .ok()
+                    .filter(|v| !v.is_empty())
+                    .or_else(|| from_toml.clone().filter(|v| !v.is_empty()))
+                    .ok_or_else(|| {
+                        format!(
+                            "remote '{name}': missing {field} (set it in muorg-server.toml or the {env_var} environment variable)"
+                        )
+                    })
+            };
+            let key_id = cred("access_key_id", &c.access_key_id)?;
+            let secret = cred("secret_access_key", &c.secret_access_key)?;
+
+            // object_store uses a supplied endpoint verbatim in virtual-hosted
+            // mode and only splices the bucket in for path-style, so do it here
+            // rather than making users encode the quirk in their config.
+            let endpoint = match &c.endpoint {
+                None => None,
+                Some(raw) => {
+                    let raw = raw.trim_end_matches('/');
+                    let (scheme, host) = raw.split_once("://").ok_or_else(|| {
+                        format!("remote '{name}': endpoint must start with http:// or https://")
+                    })?;
+                    Some(
+                        if c.virtual_hosted_style && !host.starts_with(&format!("{}.", c.bucket)) {
+                            format!("{scheme}://{}.{host}", c.bucket)
+                        } else {
+                            raw.to_string()
+                        },
+                    )
+                }
+            };
+
+            let mut b = AmazonS3Builder::new()
+                .with_bucket_name(&c.bucket)
+                .with_region(&c.region)
+                .with_access_key_id(key_id)
+                .with_secret_access_key(secret)
+                .with_virtual_hosted_style_request(c.virtual_hosted_style)
+                .with_unsigned_payload(c.unsigned_payload);
+            if let Some(ep) = &endpoint {
+                b = b.with_endpoint(ep).with_allow_http(ep.starts_with("http://"));
+            }
+            let store = b.build().map_err(|e| format!("remote '{name}': {e}"))?;
+
+            let prefix = c
+                .prefix
+                .as_deref()
+                .unwrap_or("")
+                .trim_matches('/')
+                .to_string();
+            by_name.insert(
+                name.to_string(),
+                Arc::new(RemoteStore {
+                    name: name.to_string(),
+                    store: Arc::new(store),
+                    prefix,
+                }),
+            );
+        }
+        Ok(Self { by_name })
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.by_name.is_empty()
+    }
+
+    pub fn all(&self) -> Vec<Arc<RemoteStore>> {
+        self.by_name.values().cloned().collect()
+    }
+
+    /// `remote://cloud/a/b.mp3` -> the store plus the object key. `None` for
+    /// local paths and for remote names that are not configured.
+    pub fn resolve(&self, uri: &str) -> Option<(Arc<RemoteStore>, ObjPath)> {
+        let rest = uri.strip_prefix(REMOTE_SCHEME)?;
+        let (name, key) = rest.split_once('/')?;
+        let store = self.by_name.get(name)?.clone();
+        Some((store, ObjPath::from(key)))
+    }
+
+    /// `remote://cloud` or `remote://cloud/prefix` -> the store, for dispatching
+    /// on a `roots.path` value.
+    pub fn resolve_root(&self, root: &str) -> Option<Arc<RemoteStore>> {
+        let rest = root.strip_prefix(REMOTE_SCHEME)?;
+        let name = rest.split('/').next()?;
+        self.by_name.get(name).cloned()
+    }
+}
+
+/// Downloads the whole object into a temp file whose name keeps `ext`, so the
+/// extension-based dispatch in `muorg-core` still applies.
+pub async fn fetch_to_temp(
+    remote: &RemoteStore,
+    key: &ObjPath,
+    ext: &str,
+) -> Result<tempfile::NamedTempFile, String> {
+    let bytes = remote
+        .store
+        .get(key)
+        .await
+        .map_err(|e| e.to_string())?
+        .bytes()
+        .await
+        .map_err(|e| e.to_string())?;
+    let file = tempfile::Builder::new()
+        .prefix("muorg-")
+        .suffix(&format!(".{ext}"))
+        .tempfile()
+        .map_err(|e| e.to_string())?;
+    std::fs::write(file.path(), &bytes).map_err(|e| e.to_string())?;
+    Ok(file)
+}
+
+/// Uploads `file` to `key`, returning the object's new metadata. `PutResult`
+/// carries no `last_modified`, so this heads the object afterwards — callers
+/// need the timestamp to keep `tracks.mtime_secs` in sync.
+pub async fn put_from_file(
+    remote: &RemoteStore,
+    key: &ObjPath,
+    file: &std::path::Path,
+) -> Result<ObjectMeta, String> {
+    let bytes = tokio::fs::read(file).await.map_err(|e| e.to_string())?;
+    remote
+        .store
+        .put(key, object_store::PutPayload::from(bytes::Bytes::from(bytes)))
+        .await
+        .map_err(|e| e.to_string())?;
+    remote.store.head(key).await.map_err(|e| e.to_string())
+}

--- a/server/crates/muorg-server/src/storage/mod.rs
+++ b/server/crates/muorg-server/src/storage/mod.rs
@@ -8,6 +8,7 @@
 
 pub mod covers;
 pub mod reader;
+pub mod scan;
 
 use object_store::aws::AmazonS3Builder;
 use object_store::path::Path as ObjPath;

--- a/server/crates/muorg-server/src/storage/reader.rs
+++ b/server/crates/muorg-server/src/storage/reader.rs
@@ -1,0 +1,113 @@
+//! Blocking `Read + Seek` view over an object-storage object.
+//!
+//! Lets `lofty` and `symphonia` — both of which want a seekable source — pull
+//! only the bytes they touch out of a bucket, instead of the server downloading
+//! whole tracks. Reads are served from a [`READ_WINDOW`]-sized buffer and refill
+//! with a ranged GET whenever the cursor leaves it.
+
+use bytes::Bytes;
+use object_store::path::Path as ObjPath;
+use object_store::{ObjectStore, ObjectStoreExt};
+use std::io::{self, Read, Seek, SeekFrom};
+use std::sync::Arc;
+
+/// How much is fetched per refill. Big enough that a tag read or a decode of a
+/// few frames is one request, small enough that seeking does not waste egress.
+pub const READ_WINDOW: u64 = 1024 * 1024;
+
+pub struct RemoteReader {
+    store: Arc<dyn ObjectStore>,
+    key: ObjPath,
+    handle: tokio::runtime::Handle,
+    len: u64,
+    pos: u64,
+    win: Bytes,
+    win_start: u64,
+}
+
+impl RemoteReader {
+    /// `handle` must belong to the runtime that owns `store`. Every `read` on
+    /// the result blocks on it, so a `RemoteReader` may only be driven from a
+    /// blocking thread (`tokio::task::spawn_blocking`), never a runtime worker.
+    pub fn new(
+        store: Arc<dyn ObjectStore>,
+        key: ObjPath,
+        len: u64,
+        handle: tokio::runtime::Handle,
+    ) -> Self {
+        Self {
+            store,
+            key,
+            handle,
+            len,
+            pos: 0,
+            win: Bytes::new(),
+            win_start: 0,
+        }
+    }
+
+    fn refill(&mut self) -> io::Result<()> {
+        let end = (self.pos + READ_WINDOW).min(self.len);
+        let range = self.pos..end;
+        let store = self.store.clone();
+        let key = self.key.clone();
+        let bytes = self
+            .handle
+            .block_on(async move { store.get_range(&key, range).await })
+            .map_err(io::Error::other)?;
+        self.win_start = self.pos;
+        self.win = bytes;
+        Ok(())
+    }
+}
+
+impl Read for RemoteReader {
+    fn read(&mut self, out: &mut [u8]) -> io::Result<usize> {
+        if self.pos >= self.len || out.is_empty() {
+            return Ok(0);
+        }
+        let in_window = self.pos >= self.win_start
+            && self.pos < self.win_start + self.win.len() as u64;
+        if !in_window {
+            self.refill()?;
+            if self.win.is_empty() {
+                return Ok(0);
+            }
+        }
+        let offset = (self.pos - self.win_start) as usize;
+        let n = out.len().min(self.win.len() - offset);
+        out[..n].copy_from_slice(&self.win[offset..offset + n]);
+        self.pos += n as u64;
+        Ok(n)
+    }
+}
+
+impl Seek for RemoteReader {
+    fn seek(&mut self, from: SeekFrom) -> io::Result<u64> {
+        // Pure arithmetic: a seek never costs a request, the next read refills
+        // if it landed outside the current window.
+        let target: i64 = match from {
+            SeekFrom::Start(n) => n as i64,
+            SeekFrom::End(d) => self.len as i64 + d,
+            SeekFrom::Current(d) => self.pos as i64 + d,
+        };
+        if target < 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "cannot seek before the start of the object",
+            ));
+        }
+        self.pos = (target as u64).min(self.len);
+        Ok(self.pos)
+    }
+}
+
+impl symphonia::core::io::MediaSource for RemoteReader {
+    fn is_seekable(&self) -> bool {
+        true
+    }
+
+    fn byte_len(&self) -> Option<u64> {
+        Some(self.len)
+    }
+}

--- a/server/crates/muorg-server/src/storage/scan.rs
+++ b/server/crates/muorg-server/src/storage/scan.rs
@@ -1,0 +1,206 @@
+//! Indexes an object-storage bucket into the catalog.
+//!
+//! The listing is the cheap part: one paginated LIST gives every key plus its
+//! `last_modified`, which is diffed against `tracks.mtime_secs`. Only changed or
+//! new objects cost ranged GETs for their tags, so a recurring scan of an
+//! unchanged bucket issues no per-object requests at all.
+
+use super::reader::RemoteReader;
+use super::RemoteStore;
+use muorg_core::catalog::{RootUpsert, ScannedTrack};
+use muorg_core::metadata::{AudioFormat, TrackMetadata};
+use object_store::path::Path as ObjPath;
+use object_store::{ObjectMeta, ObjectStore};
+use std::collections::HashSet;
+use std::io::{Read, Seek, SeekFrom};
+use std::sync::Arc;
+use tokio_stream::StreamExt;
+
+/// Rows per DB transaction. Pictures are stripped before batching, so a batch
+/// holds a few hundred KB rather than hundreds of MB.
+const BATCH_SIZE: usize = 200;
+
+/// Upserts logged between progress lines.
+const PROGRESS_EVERY: u64 = 500;
+
+struct Scanned {
+    uri: String,
+    format: &'static str,
+    mtime_secs: i64,
+    content_hash: Option<String>,
+    has_cover: bool,
+    meta: TrackMetadata,
+}
+
+/// Scans `remote` into the catalog and returns `(upserted, removed)`.
+pub async fn scan_remote_root(
+    state: &Arc<crate::state::AppState>,
+    remote: &Arc<RemoteStore>,
+    concurrency: usize,
+) -> Result<(u64, u64), String> {
+    let root_uri = remote.root_uri();
+
+    // A `std::sync::MutexGuard` is `!Send`, so every DB section below is a
+    // scoped block that ends before the next `.await`.
+    {
+        let conn = state.catalog.db.lock().map_err(|e| e.to_string())?;
+        muorg_core::catalog::save_roots(&conn, std::slice::from_ref(&root_uri))?;
+    }
+
+    let prefix = (!remote.prefix.is_empty()).then(|| ObjPath::from(remote.prefix.as_str()));
+    let mut listing = remote.store.list(prefix.as_ref());
+    let mut candidates: Vec<(String, ObjectMeta, AudioFormat)> = Vec::new();
+    let mut seen_uris: HashSet<String> = HashSet::new();
+    while let Some(item) = listing.next().await {
+        let meta = item.map_err(|e| e.to_string())?;
+        let key = meta.location.as_ref().to_string();
+        let format = match std::path::Path::new(&key)
+            .extension()
+            .and_then(|e| e.to_str())
+            .and_then(muorg_core::metadata::format_from_ext)
+        {
+            Some(f) => f,
+            None => continue,
+        };
+        let uri = remote.uri_for(&key);
+        seen_uris.insert(uri.clone());
+        candidates.push((uri, meta, format));
+    }
+
+    // Diff against the catalog in one locked pass. Unchanged objects are dropped
+    // here and never touched over the network.
+    let changed: Vec<(String, ObjectMeta, AudioFormat)> = {
+        let conn = state.catalog.db.lock().map_err(|e| e.to_string())?;
+        let mut changed = Vec::new();
+        for (uri, meta, format) in candidates {
+            let remote_mtime = meta.last_modified.timestamp();
+            match muorg_core::catalog::get_track_mtime_by_path(&conn, &uri)? {
+                Some(db_mtime) if db_mtime == remote_mtime => continue,
+                _ => changed.push((uri, meta, format)),
+            }
+        }
+        changed
+    };
+
+    let total = changed.len() as u64;
+    tracing::info!(root = %root_uri, total, "remote scan: objects needing a tag read");
+
+    let sem = Arc::new(tokio::sync::Semaphore::new(concurrency.max(1)));
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<Scanned>(256);
+
+    for (uri, meta, format) in changed {
+        let sem = sem.clone();
+        let tx = tx.clone();
+        let store = remote.store.clone();
+        tokio::spawn(async move {
+            let Ok(_permit) = sem.acquire().await else { return };
+            let handle = tokio::runtime::Handle::current();
+            let key = meta.location.clone();
+            let size = meta.size;
+            let read = tokio::task::spawn_blocking(move || {
+                read_tags_and_hash(store, key, size, format, handle)
+            })
+            .await;
+            match read {
+                Ok(Ok((meta_read, hash, has_cover))) => {
+                    let _ = tx
+                        .send(Scanned {
+                            uri,
+                            format: format.as_str(),
+                            mtime_secs: meta.last_modified.timestamp(),
+                            content_hash: hash,
+                            has_cover,
+                            meta: meta_read,
+                        })
+                        .await;
+                }
+                Ok(Err(e)) => tracing::warn!(key = %uri, "skipping unreadable object: {e}"),
+                Err(e) => tracing::warn!(key = %uri, "tag read task failed: {e}"),
+            }
+        });
+    }
+    drop(tx);
+
+    let mut upserted = 0u64;
+    let mut batch: Vec<Scanned> = Vec::with_capacity(BATCH_SIZE);
+    let mut last_logged = 0u64;
+    loop {
+        let item = rx.recv().await;
+        let closed = item.is_none();
+        if let Some(item) = item {
+            batch.push(item);
+        }
+        if batch.len() >= BATCH_SIZE || (closed && !batch.is_empty()) {
+            upserted += flush_batch(state, &root_uri, &batch)?;
+            batch.clear();
+            if upserted - last_logged >= PROGRESS_EVERY {
+                last_logged = upserted;
+                tracing::info!(root = %root_uri, done = upserted, total, "remote scan progress");
+            }
+        }
+        if closed {
+            break;
+        }
+    }
+
+    let removed = {
+        let conn = state.catalog.db.lock().map_err(|e| e.to_string())?;
+        muorg_core::catalog::sweep_missing_tracks(&conn, &root_uri, &seen_uris)?
+    };
+
+    Ok((upserted, removed))
+}
+
+fn flush_batch(
+    state: &Arc<crate::state::AppState>,
+    root_uri: &str,
+    batch: &[Scanned],
+) -> Result<u64, String> {
+    let conn = state.catalog.db.lock().map_err(|e| e.to_string())?;
+    let up = RootUpsert::new(&conn, root_uri)?;
+    let mut n = 0u64;
+    for item in batch {
+        up.upsert(&ScannedTrack {
+            path: &item.uri,
+            format: item.format,
+            mtime_secs: item.mtime_secs,
+            content_hash: item.content_hash.as_deref(),
+            has_cover: item.has_cover,
+            meta: &item.meta,
+        })?;
+        n += 1;
+    }
+    Ok(n)
+}
+
+/// Reads tags and the content hash off one object with a single reader, so both
+/// come out of the same ranged GETs. Runs on a blocking thread.
+fn read_tags_and_hash(
+    store: Arc<dyn ObjectStore>,
+    key: ObjPath,
+    size: u64,
+    format: AudioFormat,
+    handle: tokio::runtime::Handle,
+) -> Result<(TrackMetadata, Option<String>, bool), String> {
+    let mut r = RemoteReader::new(store, key, size, handle);
+    let mut meta = muorg_core::metadata::read_metadata_from_reader(&mut r, format)?;
+    let has_cover = meta.picture_base64.as_ref().is_some_and(|s| !s.is_empty());
+    // Only `has_cover` is persisted; drop the blob before this crosses a channel.
+    meta.picture_base64 = None;
+    meta.picture_mime = None;
+
+    let hash = if size == 0 {
+        Some(muorg_core::catalog::content_hash_from_parts(0, &[]))
+    } else {
+        let start = size.saturating_sub(muorg_core::catalog::CONTENT_HASH_TAIL_BYTES);
+        r.seek(SeekFrom::Start(start))
+            .ok()
+            .and_then(|_| {
+                let mut buf = Vec::new();
+                r.read_to_end(&mut buf).ok().map(|_| buf)
+            })
+            .map(|buf| muorg_core::catalog::content_hash_from_parts(size, &buf))
+    };
+
+    Ok((meta, hash, has_cover))
+}

--- a/server/crates/muorg-server/src/transcode.rs
+++ b/server/crates/muorg-server/src/transcode.rs
@@ -11,20 +11,38 @@ use crate::config::TranscodingConfig;
 
 type StreamTx = tokio::sync::mpsc::Sender<Result<Bytes, Box<dyn std::error::Error + Send + Sync>>>;
 
-pub fn transcode_to_mp3(path: &str, start_secs: f32, config: &TranscodingConfig, tx: StreamTx) {
-    if let Err(e) = do_transcode(path, start_secs, config, &tx) {
+/// Where a transcode reads its input. Object-storage tracks arrive as a
+/// `MediaSource` so `symphonia` pulls only the bytes it decodes instead of the
+/// server downloading whole files.
+pub enum TranscodeSource {
+    LocalPath(String),
+    Remote(Box<dyn symphonia::core::io::MediaSource>),
+}
+
+pub fn transcode_to_mp3(
+    source: TranscodeSource,
+    start_secs: f32,
+    config: &TranscodingConfig,
+    tx: StreamTx,
+) {
+    if let Err(e) = do_transcode(source, start_secs, config, &tx) {
         let _ = tx.blocking_send(Err(e));
     }
 }
 
 fn do_transcode(
-    path: &str,
+    source: TranscodeSource,
     start_secs: f32,
     config: &TranscodingConfig,
     tx: &StreamTx,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let file = std::fs::File::open(path)?;
-    let mss = MediaSourceStream::new(Box::new(file), Default::default());
+    // The label keeps the seek logs useful for both backends; the remote key
+    // itself is logged by the stream route.
+    let (ms, source_label): (Box<dyn symphonia::core::io::MediaSource>, String) = match source {
+        TranscodeSource::LocalPath(p) => (Box::new(std::fs::File::open(&p)?), p),
+        TranscodeSource::Remote(m) => (m, "<remote object>".to_string()),
+    };
+    let mss = MediaSourceStream::new(ms, Default::default());
 
     let mut format = symphonia::default::get_probe().probe(
         &Hint::new(),
@@ -67,7 +85,7 @@ fn do_transcode(
     let first_seek_packet = if start_secs > 0.0 {
         let target_secs = start_secs as f64;
 
-        tracing::info!(path, start_secs, "seek requested");
+        tracing::info!(source = %source_label, start_secs, "seek requested");
 
         let _ = format.seek(
             SeekMode::Coarse,
@@ -103,7 +121,7 @@ fn do_transcode(
             }
             skipped += 1;
         }
-        tracing::info!(path, skipped_packets = skipped, "fine-skip done");
+        tracing::info!(source = %source_label, skipped_packets = skipped, "fine-skip done");
         found
     } else {
         None

--- a/server/crates/muorg-server/tests/helpers/mod.rs
+++ b/server/crates/muorg-server/tests/helpers/mod.rs
@@ -35,6 +35,9 @@ impl TestServer {
         let catalog = Arc::new(Catalog::new(&db_path).expect("failed to open temp catalog"));
         let api_key = "test-key-123".to_string();
 
+        let cover_cache_dir = temp_dir.path().join("covers");
+        std::fs::create_dir_all(&cover_cache_dir).ok();
+
         let state = Arc::new(AppState::new(
             catalog,
             backup_dir,
@@ -42,6 +45,12 @@ impl TestServer {
             api_key.clone(),
             0, // server_port placeholder; real port will be from listener
             TranscodingConfig::default(),
+            Arc::new(muorg_server::storage::RemoteStores::default()),
+            Arc::new(muorg_server::storage::covers::CoverCache::new(
+                cover_cache_dir,
+                64 * 1024 * 1024,
+            )),
+            8,
         ));
 
         let app = build_router(state, &["*".to_string()]);

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -12,6 +12,13 @@ services:
       # Your music library — adjust the host path to wherever your music lives.
       # Match this with content_paths in muorg-server.toml.
       - /path/to/your/music:/music:ro
+    # Cloud storage credentials, if you configured [[library.remotes]].
+    # Keeping them here (from a sibling .env file) rather than in the mounted
+    # TOML means secrets never land in a config file.
+    # env_file: .env
+    # environment:
+    #   MUORG_REMOTE_CLOUD_ACCESS_KEY_ID: ${MUORG_REMOTE_CLOUD_ACCESS_KEY_ID}
+    #   MUORG_REMOTE_CLOUD_SECRET_ACCESS_KEY: ${MUORG_REMOTE_CLOUD_SECRET_ACCESS_KEY}
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "sh", "-c", "curl -sf http://localhost:7700/api/health || exit 1"]

--- a/server/muorg-server.example.toml
+++ b/server/muorg-server.example.toml
@@ -18,10 +18,17 @@ content_paths = [
 # Rescan all content_paths on startup (true) or only when triggered via API (false).
 scan_on_startup = true
 
+# How many objects to read tags from in parallel during a remote scan.
+# Must stay above the [[library.remotes]] block below — in TOML a bare key
+# after a table header belongs to that table.
+# remote_scan_concurrency = 8
+
 # ── Cloud storage (S3-compatible) ─────────────────────────────────────────────
 # Optional. Index music straight out of an S3-compatible bucket instead of (or
 # alongside) content_paths. Works with Hetzner Object Storage, Cloudflare R2,
 # Backblaze B2, Wasabi, MinIO, AWS S3, and anything else speaking the S3 API.
+#
+# Keep this block last in [library]: every key below it belongs to the remote.
 #
 # Example: Hetzner Object Storage, bucket "muorg" in Nuremberg.
 # [[library.remotes]]
@@ -33,9 +40,6 @@ scan_on_startup = true
 # prefix = ""                     # optional sub-folder inside the bucket
 # access_key_id = "..."           # or MUORG_REMOTE_CLOUD_ACCESS_KEY_ID
 # secret_access_key = "..."       # or MUORG_REMOTE_CLOUD_SECRET_ACCESS_KEY
-
-# How many objects to read tags from in parallel during a remote scan.
-# remote_scan_concurrency = 8
 
 [storage]
 # In Docker: keep these inside the /data volume so they persist across restarts.

--- a/server/muorg-server.example.toml
+++ b/server/muorg-server.example.toml
@@ -18,10 +18,34 @@ content_paths = [
 # Rescan all content_paths on startup (true) or only when triggered via API (false).
 scan_on_startup = true
 
+# ── Cloud storage (S3-compatible) ─────────────────────────────────────────────
+# Optional. Index music straight out of an S3-compatible bucket instead of (or
+# alongside) content_paths. Works with Hetzner Object Storage, Cloudflare R2,
+# Backblaze B2, Wasabi, MinIO, AWS S3, and anything else speaking the S3 API.
+#
+# Example: Hetzner Object Storage, bucket "muorg" in Nuremberg.
+# [[library.remotes]]
+# name = "cloud"                  # letters/digits/-/_ only; used internally as remote://cloud/<key>
+# bucket = "muorg"
+# endpoint = "https://nbg1.your-objectstorage.com"
+# region = "nbg1"                 # the Hetzner location code
+# virtual_hosted_style = true     # REQUIRED for Hetzner
+# prefix = ""                     # optional sub-folder inside the bucket
+# access_key_id = "..."           # or MUORG_REMOTE_CLOUD_ACCESS_KEY_ID
+# secret_access_key = "..."       # or MUORG_REMOTE_CLOUD_SECRET_ACCESS_KEY
+
+# How many objects to read tags from in parallel during a remote scan.
+# remote_scan_concurrency = 8
+
 [storage]
 # In Docker: keep these inside the /data volume so they persist across restarts.
 db_path = "/data/muorg.db"
 backup_dir = "/data/backups"
+
+# Extracted album art for cloud tracks is cached here so covers do not hit the
+# bucket on every request. Local-folder tracks are unaffected.
+# cover_cache_dir = "/data/covers"
+# cover_cache_max_bytes = 536870912   # 512 MiB
 
 [cors]
 # Origins allowed to call the API.


### PR DESCRIPTION
Adds S3-compatible object storage as a first-class music source for `muorg-server`, coexisting with local `library.content_paths`. A user adds one `[[library.remotes]]` block, restarts, and every existing client feature keeps working — library listing, search, `<audio>` playback with Range seeking, FLAC→MP3 transcoding, cover art, Chromecast, metadata editing, backups, rename.

No client changes (desktop/web/Android untouched; `client/src-tauri/` has its own private copies of the catalog/metadata modules).

## Design

- **URI scheme, no schema migration.** Remote tracks live in the existing `tracks.path` column as `remote://<name>/<key>`; roots as `remote://<name>[/<prefix>]`. `format_from_path`, the `UNIQUE(root_id, path)` constraint and the move-detection suffix query all work unchanged.
- **`object_store` 0.13**, not 0.14: 0.14 depends on `reqwest 0.13` and would compile a second reqwest/hyper/rustls stack into a binary that is also a Tauri sidecar. 0.13 unifies on the existing `reqwest 0.12` + ring-backed rustls — verified single `reqwest` in `Cargo.lock`, no `aws-lc-rs`.
- **No audio mirroring to disk.** Plain streaming translates the client `Range` 1:1 into a ranged GET and pipes the object-store byte stream through (strictly better than the local path, which reads whole files into a `Vec<u8>`). FLAC transcode, tag reads and cover extraction go through `RemoteReader`, a blocking `Read + Seek + MediaSource` with a 1 MiB read-ahead window, only ever driven from `spawn_blocking`.
- **`RootUpsert` extracted in `muorg-core`** so the remote scanner reuses the existing 4-tier move/rename detection rather than duplicating it. `scan_and_insert`'s public signature is unchanged.
- **Metadata writes** download → rewrite → re-upload, because `id3`/`lofty` need a seekable read-write file. Rare and user-initiated.
- **Cover cache on disk** for remote tracks only, keyed on `tracks.mtime_secs`; every remote write path bumps that column.
- **Endpoint normalisation.** `object_store` uses a supplied endpoint verbatim in virtual-hosted mode, so `from_config` splices the bucket into the host. Users write the plain location endpoint plus `virtual_hosted_style = true`.

## Cost model

First scan of ~60 k tracks ≈ 3 ranged GETs each at 8-way concurrency, running in the background while the server serves. Later scans: one paginated LIST, zero per-object GETs.

## Verification

Run against a **real Hetzner Object Storage bucket** (`muorg`, `nbg1`, virtual-hosted) with 180 s MP3 + FLAC fixtures carrying embedded JPEG art, and corroborated against a local MinIO (path-style, HTTP) for the checks Hetzner's intermittent throttling made non-deterministic:

| Check | Result |
|---|---|
| Scan | both tracks indexed as `remote://cloud/…`, `duration_secs = 180`, `has_cover = true`, tags correct |
| Range GET | `206`, `Content-Range: bytes 1048576-1048675/4326170`, `Content-Length: 100`, body **byte-identical** to `dd` of the source |
| Full GET | `200`, `Content-Length: 4326170`, byte-identical; `If-None-Match` → `304` |
| FLAC transcode | `format_name=mp3`, duration `180.0097`; `?start=90` → `90.044`; completes in <1 s (streams, does not pre-download) |
| Cover | `200 image/jpeg` 4499 B, byte-identical to the source's embedded art; cached to `<dir>/<id>.jpg`; `304` on revalidate; second call served from cache with no bucket request |
| Metadata write | `PATCH` → object in the bucket re-downloaded and `ffprobe` shows the new title, ETag changed, cover + duration intact, `mtime_secs` bumped |
| Backup + restore | backup is the pristine 4326170-byte original named from the `remote://` URI; restore puts it back **byte-identical** to the fixture |
| Batch write | object mutated (title + genre), `mtime_secs` bumped, FTS search finds it |
| Rescan is cheap | restart → `objects needing a tag read: 0`, `upserted=0 removed=0`, one LIST only |
| Delete detection | object removed from bucket → rescan sweeps the track |
| Rename | cross-backend → `400 Cannot move a track between storage backends`; same-remote → `200`, bucket shows `renamed.mp3`, row reused (id preserved) |
| Deleted object | stream → `404` (not `502`) |
| Bad credentials | stream → `502` (not `404`), object-store error logged |
| Third-party client | `ffprobe` over HTTP reports `mp3` / `180.000000`; `ffmpeg -ss 150` decodes cleanly |

`cargo check`, `cargo test`, `cargo clippy -- -D clippy::all` all clean; `muorg-core`'s existing `cover_extraction` tests pass untouched, which is the regression guard on the `read_metadata` refactor.

**Note on Hetzner:** this bucket intermittently returns `403 AccessDenied` for LIST/HEAD/GET — reproduced independently with `mc`, so it is provider-side, not this code. The design already tolerates it: a skipped object is never swept (it stays in the LIST result) and its `mtime` still differs, so the next scan picks it up. No 403 retry was added deliberately — retrying `AccessDenied` would mask a genuinely wrong credential.

Not exercised: the desktop-GUI seek-bar drag (no display available in the verification environment); covered instead by byte-exact range assertions and the `ffmpeg`/`ffprobe` client checks.
