### PR TITLE
✨ WEB — Gapless pre-buffer: start the next track before the current one ends (NER-314)

### DIFF
--- a/web-client/src/stores/player.ts
+++ b/web-client/src/stores/player.ts
@@ -70,6 +70,18 @@ export const usePlayerStore = defineStore("player", () => {
   );
 
   const audioEl = ref<HTMLAudioElement | null>(null);
+  /**
+   * Second hidden element that buffers the NEXT track while the current one
+   * plays, so the handoff is a resume instead of a cold start: gapless in the
+   * foreground, and the best shot iOS's suspended background page has at
+   * auto-advance (WebKit wakes it briefly at 'ended', but a fresh token fetch
+   * + src swap + play() usually gets suspended before audio starts).
+   */
+  let preloadEl: HTMLAudioElement | null = null;
+  /** The track currently sitting in `preloadEl` (null = empty/stale). */
+  let preloadedTrack: CatalogTrack | null = null;
+  /** Guards async preloads against queue changes racing the token fetch. */
+  let preloadSeq = 0;
   // FLAC seeks reload the stream, so el.currentTime restarts at 0; this holds
   // the seconds the server skipped so the wall-clock position stays right.
   let flacSeekOffset = 0;
@@ -91,13 +103,17 @@ export const usePlayerStore = defineStore("player", () => {
     }, ERROR_CLEAR_MS);
   }
 
-  function initAudio(): HTMLAudioElement {
-    if (audioEl.value) return audioEl.value;
+  /** Wires the shared listener set onto one hidden, DOM-attached audio element.
+   * Only the ACTIVE element may write playback state; the preload element fires
+   * durationchange (and briefly play/pause) while it's just buffering. */
+  function makeAudioEl(): HTMLAudioElement {
     const el = new Audio();
     el.addEventListener("timeupdate", () => {
+      if (el !== audioEl.value) return;
       positionSecs.value = el.currentTime + flacSeekOffset;
     });
     el.addEventListener("durationchange", () => {
+      if (el !== audioEl.value) return;
       if (Number.isFinite(el.duration)) {
         durationSecs.value = el.duration + flacSeekOffset;
       } else {
@@ -105,23 +121,37 @@ export const usePlayerStore = defineStore("player", () => {
       }
     });
     el.addEventListener("ended", () => {
+      if (el !== audioEl.value) return;
       isPlaying.value = false;
       positionSecs.value = 0;
       if (repeatMode.value === "one") {
         void playCurrent(0);
         return;
       }
-      advance(true);
+      const next = nextPlayOrderPos();
+      if (next < 0) return; // end of queue — playback is done
+      playOrderPos.value = next;
+      void playIndexAt(0);
     });
-    el.addEventListener("play", () => (isPlaying.value = true));
-    el.addEventListener("pause", () => (isPlaying.value = false));
+    el.addEventListener("play", () => {
+      if (el === audioEl.value) isPlaying.value = true;
+    });
+    el.addEventListener("pause", () => {
+      if (el === audioEl.value) isPlaying.value = false;
+    });
     el.volume = volume.value;
     // Must be in the DOM for the iOS Now Playing widget to register.
     el.style.display = "none";
     document.body.appendChild(el);
-    audioEl.value = el;
-    setupMediaSession();
     return el;
+  }
+
+  function initAudio(): HTMLAudioElement {
+    if (!audioEl.value) audioEl.value = makeAudioEl();
+    // reset() keeps the active element but drops the preload one — recreate it.
+    if (!preloadEl) preloadEl = makeAudioEl();
+    setupMediaSession();
+    return audioEl.value;
   }
 
   /** Rebuilds `playOrder` around `anchor` (an index into `queue`). */
@@ -162,24 +192,99 @@ export const usePlayerStore = defineStore("player", () => {
       durationSecs.value = track.duration_secs ?? 0;
       await el.play();
       recordPlay(track.id);
+      void preloadNext();
     } catch (e) {
       setError((e as Error).message);
     }
   }
 
-  /** Steps to the next entry in `playOrder`, honouring repeat-all wraparound. */
-  function advance(auto: boolean): void {
+  /** Index of the next entry in `playOrder`, or -1 at the end of the queue
+   * (repeat-all wraps around to 0). */
+  function nextPlayOrderPos(): number {
     if (playOrderPos.value + 1 < playOrder.value.length) {
-      playOrderPos.value++;
-      void playCurrent(0);
-      return;
+      return playOrderPos.value + 1;
     }
     if (repeatMode.value === "all" && playOrder.value.length > 0) {
-      playOrderPos.value = 0;
-      void playCurrent(0);
+      return 0;
+    }
+    return -1;
+  }
+
+  /** Starts the track at `playOrder[playOrderPos]`, preferring the preloaded
+   * element (a resume) over a cold start. */
+  async function playIndexAt(startSecs: number): Promise<void> {
+    if (startSecs === 0 && tryHandoffToPreloaded()) return;
+    await playCurrent(startSecs);
+  }
+
+  /**
+   * Swaps the preloaded element in as the active one if it already holds the
+   * current track with data buffered. Returns false to fall back to a cold
+   * start (stale preload, repeat-one, seek, or the buffer never filled).
+   */
+  function tryHandoffToPreloaded(): boolean {
+    const target = currentTrack.value;
+    const buf = preloadEl;
+    const old = audioEl.value;
+    if (!target || !buf || !old) return false;
+    if (preloadedTrack?.id !== target.id) return false;
+    if (buf.readyState < 2) return false; // HAVE_CURRENT_DATA — not ready yet
+
+    audioEl.value = buf;
+    preloadEl = old;
+    preloadedTrack = null;
+    // Free the old element so it becomes the next preload target.
+    old.pause();
+    old.removeAttribute("src");
+    old.load();
+    flacSeekOffset = 0;
+    positionSecs.value = 0;
+    durationSecs.value = target.duration_secs ?? 0;
+    buf.play().catch((e) => setError((e as Error).message));
+    recordPlay(target.id);
+    void preloadNext();
+    return true;
+  }
+
+  /**
+   * Starts buffering the next track (per the play order) into `preloadEl`
+   * while the current one plays. Tokens live 8h on the server
+   * (`state.tokens.issue(id, 28800)`), so a token minted now still validates
+   * whenever the handoff happens. Failure just means a cold start later.
+   */
+  async function preloadNext(): Promise<void> {
+    const buf = preloadEl;
+    if (!buf) return;
+    const nextPos = nextPlayOrderPos();
+    const next = nextPos >= 0 ? queue.value[playOrder.value[nextPos]] : null;
+    if (!next) {
+      preloadedTrack = null;
+      buf.removeAttribute("src");
+      buf.load();
       return;
     }
-    if (auto) isPlaying.value = false;
+    if (preloadedTrack?.id === next.id && buf.src) return; // already buffering it
+    const seq = ++preloadSeq;
+    try {
+      const token = await issueStreamToken(next.id);
+      if (seq !== preloadSeq || !preloadEl) return;
+      preloadedTrack = next;
+      buf.src = streamUrl(next.id, token, 0);
+      buf.load(); // preload=auto — the browser fills the buffer now
+    } catch {
+      preloadedTrack = null;
+    }
+  }
+
+  /** Steps to the next entry in `playOrder`, honouring repeat-all wraparound. */
+  function advance(auto: boolean): void {
+    const next = nextPlayOrderPos();
+    if (next < 0) {
+      if (auto) isPlaying.value = false;
+      return;
+    }
+    playOrderPos.value = next;
+    void playIndexAt(0);
   }
 
   async function playTrack(track: CatalogTrack, newQueue: CatalogTrack[]): Promise<void> {
@@ -548,6 +653,14 @@ export const usePlayerStore = defineStore("player", () => {
       el.pause();
       el.src = "";
     }
+    if (preloadEl) {
+      preloadEl.pause();
+      preloadEl.removeAttribute("src");
+      preloadEl.load();
+      preloadEl = null;
+    }
+    preloadedTrack = null;
+    preloadSeq++;
     cancelSleepTimer();
     clearTimeout(errorTimer);
     errorTimer = undefined;


### PR DESCRIPTION
## What

The web client's player now pre-buffers the next track while the current one plays, so the handoff at track end (or on skip) is a **resume**, not a cold start.

**Why:** iOS suspends a backgrounded PWA's JS. When a track ends, WebKit wakes the page just long enough for the `ended` handler to run — but a cold start (fresh token fetch → src swap → `play()`) usually gets suspended before audio starts, and the lock-screen widget clears. With the next track already buffered, the handoff is a resume that has a real chance in the background — and foreground playback becomes **gapless** (no silent gap between tracks) as a bonus.

## Changes (`web-client/src/stores/player.ts`)

- `initAudio` now creates **two** hidden DOM-attached `<audio>` elements with the same listener set; listeners guard on `el === audioEl` so only the active element writes playback state (the preload element legitimately fires `durationchange` while buffering).
- `preloadNext()` — when a track starts, issue the next track's stream token (8h server TTL — `state.tokens.issue(id, 28800)` — so it outlives the current track) and set the preload element's `src` so the browser fills the buffer. Guarded by a seq counter against queue races; failure just means a cold start later.
- `tryHandoffToPreloaded()` — on `ended` (or `skipNext` via `advance` → `playIndexAt`): if the preload element holds the current track with `readyState >= 2`, swap roles (old element becomes the preload target for the track after next) and `play()` — no reload. Otherwise falls back to the existing cold-start `playCurrent`.
- `nextPlayOrderPos()` extracted (used by both `advance` and the `ended` handler, honoring repeat-all wraparound). Repeat-one and end-of-queue behavior unchanged.
- `reset()` clears both elements.

## Verification

- `npm run build` (vue-tsc + vite) passes.
- Playwright against the mock API: 14/14 — two elements after first play, preload element buffers the next track (`readyState 4`), synthetic `ended` hands off to the buffered element with **the same src** (no cold reload), element roles swap for the following preload, second handoff advances again, `skipNext` advances via handoff, zero console errors.
- Track-row layout suite still 14/14 (no regression).

## Notes

This is best-effort for the iOS background case (WebKit bug 198277 — Apple doesn't allow reliable background auto-advance for web content); the foreground gapless improvement is unconditional. Tokens are per-track and the preload reuses the same stream URL, so no extra server load per track.